### PR TITLE
Add CustomIndicator and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,21 @@ This project implements an automated trading workflow that uses data from MT5 an
 - `signals/` – stored trading signals in JSON format
 - `logs/` – log files for debugging and monitoring
 
+## CustomIndicator
+
+The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled
+with **MetaEditor**. The indicator calculates RSI‑14, SMA‑20 and ATR‑14 for the
+current chart timeframe. If the `DisplaySignals` parameter is enabled it reads
+the latest JSON file from the `signals/` directory and shows the parsed values
+on the chart.
+
+### Compile & Attach
+
+1. Copy `CustomIndicator.mq5` to your MT5 **MQL5/Indicators** folder or open it
+   directly in MetaEditor.
+2. Press **Compile**. The compiled indicator (`CustomIndicator.ex5`) will appear
+   in the Navigator under *Indicators*.
+3. Drag the indicator onto a chart. Set `DisplaySignals` to `false` to plot
+   RSI/SMA/ATR or set it to `true` to display parsed signals.
+
 Refer to `Work_flow.md` for the full workflow description.


### PR DESCRIPTION
## Summary
- implement `CustomIndicator.mq5` for RSI14, SMA20, ATR14 and optional signal display
- document how to compile and attach the indicator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fc6a44ffc83208154a4d7d72af771