### PR TITLE
Add config support for MT5 data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ pip install -r requirements.txt
 - `signals/` – stored trading signals in JSON format
 - `logs/` – log files for debugging and monitoring
 
+## Configuration
+
+The script `scripts/fetch_mt5_data.py` reads its parameters from
+`config/fetch_mt5.json` by default. The configuration defines the trading
+symbol, how many bars to fetch for indicator calculation and the list of
+timeframes to include.
+
+Example `config/fetch_mt5.json`:
+
+```json
+{
+  "symbol": "XAUUSD",
+  "fetch_bars": 20,
+  "timeframes": [
+    {"tf": "M5", "keep": 10},
+    {"tf": "M15", "keep": 6},
+    {"tf": "H1", "keep": 4}
+  ]
+}
+```
+
 ## CustomIndicator
 
 The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled

--- a/config/fetch_mt5.json
+++ b/config/fetch_mt5.json
@@ -1,0 +1,9 @@
+{
+  "symbol": "XAUUSD",
+  "fetch_bars": 20,
+  "timeframes": [
+    {"tf": "M5", "keep": 10},
+    {"tf": "M15", "keep": 6},
+    {"tf": "H1", "keep": 4}
+  ]
+}

--- a/scripts/fetch_mt5_data.py
+++ b/scripts/fetch_mt5_data.py
@@ -1,22 +1,34 @@
 """Fetch OHLCV data from MT5 and compute indicators.
 
-This script connects to the MetaTrader5 terminal, retrieves multiple timeframes
-of OHLC data for a given symbol, calculates ATR14, RSI14 and SMA20 for each
-timeframe and saves the combined result as a CSV file.
+This script connects to the MetaTrader5 terminal and retrieves OHLCV data
+according to parameters defined in a JSON configuration file. The data is
+enriched with ATR14, RSI14 and SMA20 values before being saved to CSV.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 import pandas as pd
 import MetaTrader5 as mt5
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+TF_MAP: Dict[str, int] = {
+    "M1": mt5.TIMEFRAME_M1,
+    "M5": mt5.TIMEFRAME_M5,
+    "M15": mt5.TIMEFRAME_M15,
+    "M30": mt5.TIMEFRAME_M30,
+    "H1": mt5.TIMEFRAME_H1,
+    "H4": mt5.TIMEFRAME_H4,
+    "D1": mt5.TIMEFRAME_D1,
+}
 
 
 def _init_mt5() -> None:
@@ -28,6 +40,22 @@ def _init_mt5() -> None:
 def _shutdown_mt5() -> None:
     """Shutdown MetaTrader5 connection."""
     mt5.shutdown()
+
+
+def _load_config(path: Path) -> Dict[str, Any]:
+    """Load JSON configuration from *path*."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"Failed to read config: {exc}") from exc
+    return data
+
+
+def _tf_label(tf: str) -> str:
+    """Return a human readable label like '5m' for timeframe name."""
+    digits = "".join(ch for ch in tf if ch.isdigit())
+    letters = "".join(ch for ch in tf if ch.isalpha()).lower()
+    return f"{digits}{letters}"
 
 
 def _fetch_rates(symbol: str, timeframe: int, bars: int) -> pd.DataFrame:
@@ -73,20 +101,20 @@ def _compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def fetch_multi_tf(symbol: str) -> pd.DataFrame:
+def fetch_multi_tf(symbol: str, config: Dict[str, Any]) -> pd.DataFrame:
     """Fetch data for several timeframes and merge into one DataFrame."""
-    # Bars to keep after indicators are calculated
-    timeframes: List[tuple[int, int, str]] = [
-        (mt5.TIMEFRAME_M5, 10, "5m"),
-        (mt5.TIMEFRAME_M15, 6, "15m"),
-        (mt5.TIMEFRAME_H1, 4, "1h"),
-    ]
-    # Always fetch enough bars to compute indicators (min 20)
-    fetch_bars = 20
+    timeframes_conf = config.get("timeframes", [])
+    fetch_bars = int(config.get("fetch_bars", 20))
 
     frames = []
-    for tf, keep, label in timeframes:
-        df = _fetch_rates(symbol, tf, fetch_bars)
+    for item in timeframes_conf:
+        tf_name = str(item.get("tf", "")).upper()
+        keep = int(item.get("keep", 0))
+        tf_const = TF_MAP.get(tf_name)
+        if tf_const is None:
+            raise ValueError(f"Unsupported timeframe: {tf_name}")
+        label = _tf_label(tf_name)
+        df = _fetch_rates(symbol, tf_const, fetch_bars)
         df = _compute_indicators(df)
         df = df.tail(keep)
         df["timeframe"] = label
@@ -112,7 +140,12 @@ def fetch_multi_tf(symbol: str) -> pd.DataFrame:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch MT5 OHLC data")
-    parser.add_argument("symbol", help="Symbol to fetch", nargs="?", default="EURUSD")
+    parser.add_argument(
+        "--config",
+        help="Path to JSON config",
+        default="config/fetch_mt5.json",
+    )
+    parser.add_argument("--symbol", help="Symbol to fetch and override config")
     parser.add_argument(
         "--output",
         help="Output CSV file",
@@ -121,10 +154,13 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    config = _load_config(Path(args.config))
+    symbol = args.symbol or config.get("symbol", "EURUSD")
+
     output = (
         Path(args.output)
         if args.output
-        else Path("data/raw") / f"{args.symbol.lower()}_multi_tf.csv"
+        else Path("data/raw") / f"{symbol.lower()}_multi_tf.csv"
     )
 
     logging.basicConfig(
@@ -134,7 +170,7 @@ def main() -> None:
 
     try:
         _init_mt5()
-        df = fetch_multi_tf(args.symbol)
+        df = fetch_multi_tf(symbol, config)
         output.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(output, index=False)
         LOGGER.info("Saved data to %s", output)


### PR DESCRIPTION
## Summary
- add JSON config file for controlling MT5 data fetch parameters
- load config in `scripts/fetch_mt5_data.py`
- document configuration in README

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684fded897b48320a06d02cd837690d9