### PR TITLE
Add tz_shift configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ using `--config`. The configuration defines:
 - `fetch_bars` – number of historical bars requested for indicator calculation.
 - `timeframes` – list of timeframes, each with `tf` (timeframe code) and `keep`
   (how many bars of that timeframe to retain).
+- `tz_shift` – hours to shift timestamps. If omitted the default is `0`.
 
 You can adjust timestamps with the `--tz-shift` option. For example, if the
 server time is GMT+3 and you need GMT+7 data, pass `--tz-shift 4`.
@@ -42,6 +43,7 @@ Example `config/fetch_mt5.json`:
 
 ```json
 {
+  "tz_shift": 4,
   "symbol": "XAUUSD",
   "fetch_bars": 20,
   "timeframes": [

--- a/scripts/fetch/config/fetch_mt5.json
+++ b/scripts/fetch/config/fetch_mt5.json
@@ -1,4 +1,5 @@
 {
+  "tz_shift": 4,
   "symbol": "XAUUSD",
   "fetch_bars": 30,
   "timeframes": [

--- a/scripts/fetch/fetch_mt5_data.py
+++ b/scripts/fetch/fetch_mt5_data.py
@@ -145,11 +145,20 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Fetch MT5 OHLC data")
-    parser.add_argument(
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument(
         "--config",
         help="Path to JSON config",
         default="config/fetch_mt5.json",
+    )
+
+    # First parse only --config to determine defaults from file
+    pre_args, remaining = pre_parser.parse_known_args()
+    config = _load_config(Path(pre_args.config))
+    default_tz = int(config.get("tz_shift", 0))
+
+    parser = argparse.ArgumentParser(
+        description="Fetch MT5 OHLC data", parents=[pre_parser]
     )
     parser.add_argument("--symbol", help="Symbol to fetch and override config")
     parser.add_argument(
@@ -160,13 +169,12 @@ def main() -> None:
     parser.add_argument(
         "--tz-shift",
         type=int,
-        default=0,
+        default=default_tz,
         help="Hours to shift timestamps (e.g. 4 for GMT+3 to GMT+7)",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(remaining)
 
-    config = _load_config(Path(args.config))
     symbol = args.symbol or config.get("symbol", "EURUSD")
 
     output = Path(args.output) if args.output else None


### PR DESCRIPTION
## Summary
- support `tz_shift` field in config and CLI
- document timestamp shift option
- update example config with `tz_shift`

## Testing
- `python -m py_compile scripts/fetch/fetch_mt5_data.py`

------
https://chatgpt.com/codex/tasks/task_e_684fedfd31d0832080e736d5265b5128