### PR TITLE
Fix timestamp reset handling

### DIFF
--- a/scripts/fetch/fetch_yf_data.py
+++ b/scripts/fetch/fetch_yf_data.py
@@ -56,6 +56,7 @@ def _fetch_rates(symbol: str, interval: str, bars: int, tz_shift: int = 0) -> pd
     if idx.tzinfo is not None:
         idx = idx.tz_convert(None)
     df.index = idx + pd.Timedelta(hours=tz_shift)
+    df.index.name = "timestamp"
     df = df.rename(
         columns={
             "Open": "open",
@@ -65,7 +66,7 @@ def _fetch_rates(symbol: str, interval: str, bars: int, tz_shift: int = 0) -> pd
             "Volume": "tick_volume",
         }
     )
-    df = df.reset_index().rename(columns={"index": "timestamp"})
+    df = df.reset_index()
     df = df[["timestamp", "open", "high", "low", "close", "tick_volume"]]
     return df
 


### PR DESCRIPTION
## Summary
- ensure `_fetch_rates` in yfinance workflow preserves timestamp column name

## Testing
- `python -m py_compile scripts/fetch/fetch_mt5_data.py scripts/fetch/fetch_yf_data.py scripts/parse_gpt_response.py scripts/send_to_gpt.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff23a56a8832085492424bff9263b