### PR TITLE
Fix Yahoo Finance symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Example `config/fetch_mt5.json`:
 ```
 
 The script `scripts/fetch_yf_data.py` provides similar functionality using yfinance. It loads `config/fetch_yf.json` and accepts the same command-line options.
+When fetching currency data from Yahoo Finance make sure to use the Yahoo symbol
+format that appends `=X` to the pair, for example `XAUUSD=X`.
 
 ## CustomIndicator
 

--- a/scripts/fetch/config/fetch_yf.json
+++ b/scripts/fetch/config/fetch_yf.json
@@ -1,6 +1,6 @@
 {
   "tz_shift": 7,
-  "symbol": "XAUUSD",
+  "symbol": "XAUUSD=X",
   "fetch_bars": 30,
   "timeframes": [
     {"tf": "M5", "keep": 10},


### PR DESCRIPTION
## Summary
- fix example config for Yahoo Finance
- document `=X` suffix for currency pairs when fetching data via yfinance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff89757b083208c605c76b7a990ac