### PR TITLE
Add config support for GPT script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ It loads `config/fetch_yf.json` and accepts the same command-line options.
 When fetching currency pairs from Yahoo Finance use the `=X` suffix (e.g. `EURUSD=X`).
 To download gold prices for `XAUUSD` configure the symbol as `GC=F`.
 
+The `scripts/send_to_gpt.py` script also reads default values from a JSON file.
+It loads `config/gpt.json` unless you pass an alternative path with `--config`.
+Example `config/gpt.json`:
+
+```json
+{
+  "openai_api_key": "YOUR_API_KEY",
+  "prompt": "Generate signal",
+  "model": "gpt-3.5-turbo"
+}
+```
+
+Values provided on the command line override those in the config file.
+For the API key the `OPENAI_API_KEY` environment variable takes precedence over
+the `openai_api_key` value in the JSON config.
+
 ## CustomIndicator
 
 The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled

--- a/scripts/config/gpt.json
+++ b/scripts/config/gpt.json
@@ -1,0 +1,5 @@
+{
+  "openai_api_key": "YOUR_API_KEY",
+  "prompt": "Generate signal",
+  "model": "gpt-3.5-turbo"
+}


### PR DESCRIPTION
## Summary
- create `scripts/config/gpt.json` example config
- allow `send_to_gpt.py` to load defaults from JSON
- document new config file and precedence in README

## Testing
- `python -m py_compile scripts/*.py scripts/fetch/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6850063bc88883209a402b82612b7976