### PR TITLE
Improve send_to_gpt CSV handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Values provided on the command line override those in the config file.
 For the API key the `OPENAI_API_KEY` environment variable takes precedence over
 the `openai_api_key` value in the JSON config.
 
+If you omit the positional `csv` argument, `send_to_gpt.py` automatically
+searches the directory specified by `--data-dir` (default `data/raw`) and uses
+the newest `*.csv` file it finds. The selected file path is reported in the
+logs and the script exits with an error if no CSV files are available.
+
 ## CustomIndicator
 
 The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled


### PR DESCRIPTION
## Summary
- make CSV argument optional in `send_to_gpt.py`
- automatically find the newest CSV in a data directory
- log which CSV file is used
- document new behaviour

## Testing
- `python -m py_compile scripts/send_api/send_to_gpt.py`
- `PYTHONPATH=/tmp/stub_openai python scripts/send_api/send_to_gpt.py --prompt test --model dummy --config scripts/send_api/config/gpt.json`

------
https://chatgpt.com/codex/tasks/task_e_6850091320508320ac8bb9740aae6745