### PR TITLE
Update default GPT model and JSON prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Example `config/gpt.json`:
 ```json
 {
   "openai_api_key": "YOUR_API_KEY",
-  "prompt": "Generate signal",
-  "model": "gpt-3.5-turbo",
+  "prompt": "Generate a trading signal and reply only with a JSON object like {\"signal_id\": \"xauusd-20250616_14hr\", \"entry\": 12, \"sl\": 10, \"tp\": 20, \"position_type\": \"buy limit\", \"confidence\": 77 }",
+  "model": "gpt-4o",
   "csv": "path/to/file.csv"
 }
 ```

--- a/scripts/send_api/config/gpt.json
+++ b/scripts/send_api/config/gpt.json
@@ -1,6 +1,6 @@
 {
   "openai_api_key": "YOUR_API_KEY",
-  "prompt": "Generate signal",
-  "model": "gpt-3.5-turbo",
+  "prompt": "Generate a trading signal and reply only with a JSON object like {\"signal_id\": \"xauusd-20250616_14hr\", \"entry\": 12, \"sl\": 10, \"tp\": 20, \"position_type\": \"buy limit\", \"confidence\": 77 }",
+  "model": "gpt-4o",
   "csv": "data/raw/example.csv"
 }

--- a/scripts/send_api/send_to_gpt.py
+++ b/scripts/send_api/send_to_gpt.py
@@ -71,13 +71,16 @@ def main() -> None:
     parser.add_argument(
         "--prompt",
         help="Prompt text",
-        default=config.get("prompt", "Generate signal"),
+        default=config.get(
+            "prompt",
+            "Generate a trading signal and reply only with a JSON object like {\\\"signal_id\\\": \\\"xauusd-20250616_14hr\\\", \\\"entry\\\": 12, \\\"sl\\\": 10, \\\"tp\\\": 20, \\\"position_type\\\": \\\"buy limit\\\", \\\"confidence\\\": 77 }",
+        ),
     )
     parser.add_argument("--prompt-file", help="Read prompt from file")
     parser.add_argument(
         "--model",
         help="Model name",
-        default=config.get("model", "gpt-3.5-turbo"),
+        default=config.get("model", "gpt-4o"),
     )
     parser.add_argument("--output", help="Save raw response to file")
 


### PR DESCRIPTION
## Summary
- change default model to `gpt-4o`
- update prompt so GPT replies with JSON only
- update example config in README

## Testing
- `python -m py_compile scripts/send_api/send_to_gpt.py`
- `python -m py_compile scripts/parse_gpt_response.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68500e8bf3e083208e40c36bf5bd757e