### PR TITLE
Add response logging and flexible output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ If you omit the positional `csv` argument, `send_to_gpt.py` first checks
 selected file path is reported in the logs and the script exits with an error if
 no CSV files are available.
 
+The parser `scripts/parse_gpt_response.py` reads a raw GPT reply and writes the
+structured result to a JSON file. Use `--csv-log` to set the path for logging
+every response (default `logs/responses.csv`) and `--json-dir` to choose the
+directory for generated JSON signals (default `signals`). Each run appends a row
+to the CSV log with the key values from the signal and saves the parsed data in
+a uniquely named file like `250616_153045.json` inside the configured
+directory.
+
 ## Running the complete workflow
 
 Once the individual scripts are configured you can execute the whole process in


### PR DESCRIPTION
## Summary
- add csv logging and json directory options to `parse_gpt_response.py`
- log raw GPT replies
- store signal details in `logs/responses.csv`
- save each parsed signal under `signals/` with a unique timestamped filename
- document new options in the README

## Testing
- `python -m py_compile scripts/parse_gpt_response.py`

------
https://chatgpt.com/codex/tasks/task_e_685014a605788320a7803602b2f9fe60