### PR TITLE
Update GPT script for new OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Install the Python dependencies:
 ```bash
 pip install -r requirements.txt
 ```
+This project requires the OpenAI Python library version 1.0 or newer.
 
 ## Directory Structure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 MetaTrader5
-openai
+openai>=1.0
 yfinance


### PR DESCRIPTION
## Summary
- use `openai.OpenAI` client instead of deprecated `openai.ChatCompletion`
- pin `openai>=1.0` and document the version requirement

## Testing
- `python -m py_compile scripts/send_api/send_to_gpt.py`

------
https://chatgpt.com/codex/tasks/task_e_68501d9c7da0832099f70766a852071c