### PR TITLE
Allow custom save path for yfinance fetch

### DIFF
--- a/scripts/fetch/config/fetch_yf.json
+++ b/scripts/fetch/config/fetch_yf.json
@@ -2,6 +2,7 @@
   "tz_shift": 7,
   "symbol": "GC=F",
   "fetch_bars": 30,
+  "save_as_path": "scripts/fetch/data/raw",
   "timeframes": [
     {"tf": "M5", "keep": 10},
     {"tf": "M15", "keep": 6},

--- a/scripts/fetch/fetch_yf_data.py
+++ b/scripts/fetch/fetch_yf_data.py
@@ -144,6 +144,7 @@ def main() -> None:
     pre_args, remaining = pre_parser.parse_known_args()
     config = _load_config(Path(pre_args.config))
     default_tz = int(config.get("tz_shift", 0))
+    default_save_path = config.get("save_as_path", "data/raw")
 
     parser = argparse.ArgumentParser(description="Fetch yfinance OHLC data", parents=[pre_parser])
     parser.add_argument("--symbol", help="Symbol to fetch and override config")
@@ -169,7 +170,7 @@ def main() -> None:
             h1_df = df[df["timeframe"] == h1_label]
             last_ts = h1_df["timestamp"].max() if not h1_df.empty else df["timestamp"].max()
             name = _timestamp_code(last_ts)
-            output = Path("data/raw") / f"{symbol.lower()}_{name}.csv"
+            output = Path(default_save_path) / f"{symbol.lower()}_{name}.csv"
         output.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(output, index=False)
         LOGGER.info("Saved data to %s", output)


### PR DESCRIPTION
## Summary
- make `fetch_yf_data.py` read a `save_as_path` option from config
- add `save_as_path` to `fetch_yf.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850446b3978832081cdf7e9c9312985