### PR TITLE
Adjust default prompt generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,17 @@ It loads `scripts/fetch/config/fetch_yf.json` and accepts the same command-line 
 When fetching currency pairs from Yahoo Finance use the `=X` suffix (e.g. `EURUSD=X`).
 To download gold prices for `XAUUSD` configure the symbol as `GC=F`.
 
-The `scripts/send_api/send_to_gpt.py` script also reads default values from a JSON file.
-Copy `scripts/send_api/config/gpt.example.json` to `scripts/send_api/config/gpt.json` and fill in your API key.
-The script loads `scripts/send_api/config/gpt.json` unless you pass an alternative path with `--config`.
+The `scripts/send_api/send_to_gpt.py` script reads its API key and other settings from
+`scripts/send_api/config/gpt.json`. Copy `scripts/send_api/config/gpt.example.json`
+to `scripts/send_api/config/gpt.json` and fill in your API key. The prompt is
+generated automatically from the CSV file name unless you override it on the
+command line. The script loads `scripts/send_api/config/gpt.json` unless you pass
+an alternative path with `--config`.
 Example `scripts/send_api/config/gpt.json`:
 
 ```json
 {
   "openai_api_key": "YOUR_API_KEY",
-  "prompt": "Generate a trading signal and reply only with a JSON object like {\"signal_id\": \"xauusd-20250616_14hr\", \"entry\": 12, \"sl\": 10, \"tp\": 20, \"position_type\": \"buy limit\", \"confidence\": 77 }",
   "model": "gpt-4o",
   "csv_file": "",
   "csv_path": "data/raw"

--- a/Work_flow.md
+++ b/Work_flow.md
@@ -40,7 +40,7 @@ json
 "entry": 12,
 "sl": 10,
 "tp": 20,
-"position_type": "buy limit",
+"pending_order_type": "buy limit",
 "confidence": 77
 }
 3.5 Parse response to JSON file & save to folder
@@ -91,7 +91,7 @@ Modular, debug/ปรับปรุงทุกจุดได้
    "entry": 2332.14,
    "sl": 2327.50,
    "tp": 2340.50,
-   "position_type": "buy limit",
+   "pending_order_type": "buy limit",
    "confidence": 81
    }
 7. Extensibility

--- a/latest_response.txt
+++ b/latest_response.txt
@@ -1,3 +1,3 @@
 ```json
-{"signal_id": "xauusd-20250616_14hr", "entry": 3411, "sl": 3402, "tp": 3425, "position_type": "buy limit", "confidence": 77}
+{"signal_id": "xauusd-20250616_14hr", "entry": 3411, "sl": 3402, "tp": 3425, "pending_order_type": "buy limit", "confidence": 77}
 ```

--- a/scripts/parse_gpt_response.py
+++ b/scripts/parse_gpt_response.py
@@ -137,7 +137,7 @@ def main() -> None:
         "entry": data.get("entry"),
         "sl": data.get("sl"),
         "tp": data.get("tp"),
-        "position_type": data.get("position_type"),
+        "pending_order_type": data.get("pending_order_type"),
         "confidence": data.get("confidence"),
     }
     is_new = not csv_path.exists()
@@ -151,7 +151,7 @@ def main() -> None:
                     "entry",
                     "sl",
                     "tp",
-                    "position_type",
+                    "pending_order_type",
                     "confidence",
                 ],
             )

--- a/scripts/send_api/config/gpt.example.json
+++ b/scripts/send_api/config/gpt.example.json
@@ -1,6 +1,5 @@
 {
   "openai_api_key": "YOUR_API_KEY",
-  "prompt": "Generate a trading signal and reply only with a JSON object like {\"signal_id\": \"xauusd-20250616_14hr\", \"entry\": 12, \"sl\": 10, \"tp\": 20, \"position_type\": \"buy limit\", \"confidence\": 77 }",
   "model": "gpt-4o",
   "csv_file": "",
   "csv_path": "scripts/fetch/data/raw"

--- a/scripts/signals/path_latest_response.txt
+++ b/scripts/signals/path_latest_response.txt
@@ -1,3 +1,3 @@
 ```json
-{"signal_id": "xauusd-20250616_14hr", "entry": 3411, "sl": 3402, "tp": 3425, "position_type": "buy limit", "confidence": 77}
+{"signal_id": "xauusd-20250616_14hr", "entry": 3411, "sl": 3402, "tp": 3425, "pending_order_type": "buy limit", "confidence": 77}
 ```


### PR DESCRIPTION
## Summary
- generate GPT prompt from CSV filename
- drop `prompt` field from example config
- handle `pending_order_type` in parsed JSON
- update workflow docs and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685055a3179883209b7102dc15dd977f