### PR TITLE
Update default prompt instructions

### DIFF
--- a/scripts/send_api/send_to_gpt.py
+++ b/scripts/send_api/send_to_gpt.py
@@ -17,7 +17,9 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_PROMPT = (
     "Generate a trading signal and reply only with a JSON object like "
     '{"signal_id": "%s", "entry": , "sl": , "tp": , '
-    '"pending_order_type": "", "confidence":  }'
+    '"pending_order_type": "", "confidence":  }. '
+    "pending_order_type must be one of [buy_limit, sell_limit, buy_stop, "
+    "sell_stop] and confidence is an integer percentage between 1 and 100."
 )
 
 


### PR DESCRIPTION
## Summary
- clarify allowed pending order types in the default GPT prompt
- specify confidence as an integer percentage from 1-100

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505908eb648320a52905de5bf1b6dc