### PR TITLE
Unify pending order field

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled
 with **MetaEditor**. The indicator calculates RSI‑14, SMA‑20 and ATR‑14 for the
 current chart timeframe. If the `DisplaySignals` parameter is enabled it reads
 the latest JSON file from the `signals_json/` directory and shows the parsed values
-on the chart.
+on the chart. Each JSON signal must include the fields `signal_id`, `entry`, `sl`,
+`tp`, `pending_order_type` and `confidence`.
 
 ### Compile & Attach
 

--- a/ea/CustomIndicator.mq5
+++ b/ea/CustomIndicator.mq5
@@ -40,7 +40,7 @@ struct SignalData
    double entry;
    double sl;
    double tp;
-   string position;
+   string order_type;
    double confidence;
   };
 SignalData current_signal;
@@ -122,7 +122,7 @@ int OnCalculate(const int rates_total,
      {
       string msg = StringFormat("Signal %s %s\nEntry: %.2f SL: %.2f TP: %.2f Conf: %.0f",
                                 current_signal.id,
-                                current_signal.position,
+                                current_signal.order_type,
                                 current_signal.entry,
                                 current_signal.sl,
                                 current_signal.tp,
@@ -193,7 +193,7 @@ void ParseSignal(string json, SignalData &sig)
    sig.entry = StringToDouble(GetValue(json,"entry"));
    sig.sl = StringToDouble(GetValue(json,"sl"));
    sig.tp = StringToDouble(GetValue(json,"tp"));
-   sig.position = GetValue(json,"position_type");
+   sig.order_type = GetValue(json,"pending_order_type");
    sig.confidence = StringToDouble(GetValue(json,"confidence"));
   }
 


### PR DESCRIPTION
## Summary
- use `pending_order_type` in CustomIndicator
- document required JSON fields in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d7100140832083775f34cfeab46b