### PR TITLE
Fix typing import and test fetch_yf

### DIFF
--- a/scripts/fetch/fetch_yf_data.py
+++ b/scripts/fetch/fetch_yf_data.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pandas as pd
 import yfinance as yf

--- a/tests/test_fetch_yf_data.py
+++ b/tests/test_fetch_yf_data.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.fetch.fetch_yf_data import fetch_multi_tf
+
+
+def _fake_download(symbol: str, interval: str, period: str, progress: bool) -> pd.DataFrame:
+    """Return a small DataFrame for testing."""
+    index = pd.date_range("2024-01-01", periods=5, freq="min")
+    return pd.DataFrame(
+        {
+            "Open": range(5),
+            "High": range(5),
+            "Low": range(5),
+            "Close": range(5),
+            "Volume": range(5),
+        },
+        index=index,
+    )
+
+
+def test_fetch_multi_tf_returns_dataframe() -> None:
+    config = {"fetch_bars": 5, "timeframes": [{"tf": "M1", "keep": 5}]}
+    with patch("scripts.fetch.fetch_yf_data.yf.download", side_effect=_fake_download):
+        df = fetch_multi_tf("TEST", config, tz_shift=0)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty


### PR DESCRIPTION
## Summary
- fix fetch_yf_data typing import by adding `List`
- add unit test for `fetch_multi_tf`

## Testing
- `python scripts/fetch/fetch_yf_data.py --help` *(fails: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850dea83bcc832085b64cc5493c24d2