### PR TITLE
Add main config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ a single command:
 python main.py
 ```
 
+`main.py` reads default settings from `config/main.json`. Pass `--config` with a
+different path to use custom values. Command-line options override the config
+entries.
+
 The `main.py` helper runs the fetch step, sends the result to the GPT API and
 parses the raw response into a JSON signal. Use `--fetch-script`, `--send-script`
 and `--parse-script` to override the default script locations. You can also

--- a/config/main.json
+++ b/config/main.json
@@ -1,0 +1,10 @@
+{
+  "fetch_type": "yf",
+  "fetch_script": "",
+  "send_script": "scripts/send_api/send_to_gpt.py",
+  "parse_script": "scripts/parse_response/parse_gpt_response.py",
+  "response": "data/signals/latest_response.txt",
+  "skip_fetch": false,
+  "skip_send": false,
+  "skip_parse": false
+}

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import sys
 from pathlib import Path
@@ -20,51 +21,79 @@ async def _run_step(step: str, script: Path, *args: str) -> None:
         raise RuntimeError(f"{step} failed with code {proc.returncode}")
 
 
+def _load_config(path: Path) -> dict:
+    """Load JSON configuration from *path*."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"Failed to read config: {exc}") from exc
+
+
 async def main() -> None:
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    default_cfg = Path(__file__).resolve().parent / "config" / "main.json"
+    pre_parser.add_argument(
+        "--config", help="Path to JSON config", default=str(default_cfg)
+    )
+
+    pre_args, remaining = pre_parser.parse_known_args()
+    try:
+        config = _load_config(Path(pre_args.config))
+    except Exception as exc:  # noqa: BLE001
+        logging.error("%s", exc)
+        raise SystemExit(1)
+
     parser = argparse.ArgumentParser(
         description="Fetch data, send to GPT and parse the response sequentially",
+        parents=[pre_parser],
     )
     parser.add_argument(
         "--fetch-type",
         choices=["yf", "mt5"],
-        default="yf",
+        default=config.get("fetch_type", "yf"),
         help="Select built-in data fetcher (ignored if --fetch-script is set)",
     )
     parser.add_argument(
         "--fetch-script",
+        default=config.get("fetch_script"),
         help="Path to data fetching script (overrides --fetch-type)",
     )
     parser.add_argument(
         "--send-script",
-        default="scripts/send_api/send_to_gpt.py",
+        default=config.get("send_script", "scripts/send_api/send_to_gpt.py"),
         help="Path to GPT API script",
     )
     parser.add_argument(
         "--parse-script",
-        default="scripts/parse_response/parse_gpt_response.py",
+        default=config.get(
+            "parse_script", "scripts/parse_response/parse_gpt_response.py"
+        ),
         help="Path to response parsing script",
     )
     parser.add_argument(
         "--response",
-        default="data/signals/latest_response.txt",
+        default=config.get("response", "data/signals/latest_response.txt"),
         help="Temporary file to store raw GPT response",
     )
     parser.add_argument(
         "--skip-fetch",
         action="store_true",
+        default=bool(config.get("skip_fetch", False)),
         help="Skip the data fetching step",
     )
     parser.add_argument(
         "--skip-send",
         action="store_true",
+        default=bool(config.get("skip_send", False)),
         help="Skip sending data to GPT",
     )
     parser.add_argument(
         "--skip-parse",
         action="store_true",
+        default=bool(config.get("skip_parse", False)),
         help="Skip parsing the GPT response",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(remaining)
 
     if args.fetch_script is None:
         fetch_map = {


### PR DESCRIPTION
## Summary
- add new `config/main.json` for workflow defaults
- load optional config file in `main.py`
- document new config in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850dfc4951c8320b924956f19b5f30e