### PR TITLE
Add timezone shift tests

### DIFF
--- a/tests/test_fetch_mt5_data.py
+++ b/tests/test_fetch_mt5_data.py
@@ -1,0 +1,49 @@
+import sys
+import importlib
+from types import ModuleType
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_fetch_multi_tf_tz_shift_and_latest_bar() -> None:
+    """Ensure timestamps shift and latest bar is included."""
+    sample_times = pd.date_range("2024-01-01", periods=5, freq="min")[::-1]
+    sample_rates = [
+        {
+            "time": int(ts.timestamp()),
+            "open": i,
+            "high": i,
+            "low": i,
+            "close": i,
+            "tick_volume": i,
+            "spread": 0,
+            "real_volume": 0,
+        }
+        for i, ts in enumerate(sample_times)
+    ]
+
+    mt5 = ModuleType("MetaTrader5")
+    mt5.TIMEFRAME_M1 = 1
+    mt5.TIMEFRAME_M5 = 2
+    mt5.TIMEFRAME_M15 = 3
+    mt5.TIMEFRAME_M30 = 4
+    mt5.TIMEFRAME_H1 = 5
+    mt5.TIMEFRAME_H4 = 6
+    mt5.TIMEFRAME_D1 = 7
+    mt5.copy_rates_from_pos = lambda *args, **kwargs: sample_rates
+
+    with importlib.import_module("unittest.mock").patch.dict(
+        sys.modules, {"MetaTrader5": mt5}
+    ):
+        fetch_mt5_data = importlib.import_module("scripts.fetch.fetch_mt5_data")
+        importlib.reload(fetch_mt5_data)
+
+        config = {"fetch_bars": 5, "timeframes": [{"tf": "M1", "keep": 5}]}
+        df = fetch_mt5_data.fetch_multi_tf("TEST", config, tz_shift=2)
+
+    expected_times = sample_times + pd.Timedelta(hours=2)
+    assert list(df["timestamp"]) == list(expected_times)
+    assert df["timestamp"].iloc[0] == expected_times[0]

--- a/tests/test_fetch_yf_data.py
+++ b/tests/test_fetch_yf_data.py
@@ -9,7 +9,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.fetch.fetch_yf_data import fetch_multi_tf
 
 
-def _fake_download(symbol: str, interval: str, period: str, progress: bool) -> pd.DataFrame:
+def _fake_download(
+    symbol: str, interval: str, period: str, progress: bool
+) -> pd.DataFrame:
     """Return a small DataFrame for testing."""
     index = pd.date_range("2024-01-01", periods=5, freq="min")
     return pd.DataFrame(
@@ -30,3 +32,15 @@ def test_fetch_multi_tf_returns_dataframe() -> None:
         df = fetch_multi_tf("TEST", config, tz_shift=0)
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
+
+
+def test_tz_shift_applied() -> None:
+    """Timestamps should shift by the tz_shift value."""
+    config = {"fetch_bars": 5, "timeframes": [{"tf": "M1", "keep": 5}]}
+    with patch("scripts.fetch.fetch_yf_data.yf.download", side_effect=_fake_download):
+        df = fetch_multi_tf("TEST", config, tz_shift=3)
+
+    expected = pd.date_range("2024-01-01", periods=5, freq="min") + pd.Timedelta(
+        hours=3
+    )
+    assert list(df["timestamp"]) == list(expected)


### PR DESCRIPTION
## Summary
- test timezone shifting with yfinance data
- mock MetaTrader5 and ensure fetch_mt5_data handles tz_shift and latest bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850e2b2266c8320994f0b6cde9e531a