### PR TITLE
Fix MT5 fetch ordering

### DIFF
--- a/scripts/fetch/fetch_mt5_data.py
+++ b/scripts/fetch/fetch_mt5_data.py
@@ -70,6 +70,7 @@ def _fetch_rates(symbol: str, timeframe: int, bars: int, tz_shift: int = 0) -> p
     if rates is None:
         raise RuntimeError(f"Failed to fetch data for {symbol} timeframe {timeframe}")
     df = pd.DataFrame(rates)
+    df = df.sort_values("time").reset_index(drop=True)
     df["timestamp"] = pd.to_datetime(df["time"], unit="s") + pd.Timedelta(hours=tz_shift)
     df = df.drop(columns=["time", "spread", "real_volume"], errors="ignore")
     return df

--- a/tests/test_fetch_mt5_data.py
+++ b/tests/test_fetch_mt5_data.py
@@ -44,6 +44,6 @@ def test_fetch_multi_tf_tz_shift_and_latest_bar() -> None:
         config = {"fetch_bars": 5, "timeframes": [{"tf": "M1", "keep": 5}]}
         df = fetch_mt5_data.fetch_multi_tf("TEST", config, tz_shift=2)
 
-    expected_times = sample_times + pd.Timedelta(hours=2)
+    expected_times = pd.date_range("2024-01-01", periods=5, freq="min") + pd.Timedelta(hours=2)
     assert list(df["timestamp"]) == list(expected_times)
-    assert df["timestamp"].iloc[0] == expected_times[0]
+    assert df["timestamp"].iloc[-1] == expected_times[-1]


### PR DESCRIPTION
## Summary
- sort MT5 rates by time before computing indicators
- update MT5 unit test for ascending timestamps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850e8c7decc8320b25446b9dd7376ef