### PR TITLE
Add coding standard guideline

### DIFF
--- a/CODE_STANDARD.md
+++ b/CODE_STANDARD.md
@@ -1,0 +1,10 @@
+# Coding Standards
+
+This project follows a simple guideline to keep input/output operations separate from business logic.
+
+1. **Pure functions for logic** – Calculations, data transformations and API wrappers should be implemented as functions that accept arguments and return data without performing file or network I/O on their own.
+2. **I/O in CLI layers** – Reading configuration files, loading CSV data, sending requests or writing results should be handled in small wrappers or in the `main()` functions of scripts.
+3. **Testability** – Separating logic from I/O makes it easier to write unit tests. Aim to design functions so they can be tested without external resources.
+4. **Documentation** – Keep this policy in mind when adding new modules or scripts. Update this file if exceptions are required.
+
+Following these rules keeps the codebase maintainable and easier to extend.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ This project requires the OpenAI Python library version 1.0 or newer.
 - `ea/` – Expert Advisor or trading automation code
 - `logs/` – log files for debugging and monitoring
 
+## Coding Standards
+
+The scripts in this repository aim to keep input/output operations separate from
+business logic. See [CODE_STANDARD.md](CODE_STANDARD.md) for details.
+
 ## Configuration
 
 The script `scripts/fetch/fetch_mt5_data.py` reads its parameters from


### PR DESCRIPTION
## Summary
- document rule to keep I/O separate from business logic
- link the coding guideline from the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685145a6f0248320b287768d7bdb515d