### PR TITLE
Refactor send_to_gpt.py for IO separation

### DIFF
--- a/tests/test_send_to_gpt.py
+++ b/tests/test_send_to_gpt.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.send_api.send_to_gpt import _build_messages
+
+
+def test_build_messages() -> None:
+    messages = _build_messages("a,b", "Prompt")
+    assert messages[0]["role"] == "system"
+    assert "trading data" in messages[0]["content"]
+    assert messages[1]["role"] == "user"
+    assert "Prompt" in messages[1]["content"]
+    assert "a,b" in messages[1]["content"]


### PR DESCRIPTION
## Summary
- separate message construction from API calls in `send_to_gpt.py`
- import OpenAI lazily so tests can run without the package
- add unit test for `_build_messages`

## Testing
- `pytest tests/test_parse_gpt_response.py tests/test_send_to_gpt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68514673d5e48320b17b3bcc752417b9