### PR TITLE
Handle missing fetch script

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -1,6 +1,6 @@
 {
   "fetch_type": "yf",
-  "fetch_script": "",
+  "fetch_script": null,
   "send_script": "scripts/send_api/send_to_gpt.py",
   "parse_script": "scripts/parse_response/parse_gpt_response.py",
   "response": "data/signals/latest_response.txt",

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ async def main() -> None:
     )
     args = parser.parse_args(remaining)
 
-    if args.fetch_script is None:
+    if not args.fetch_script:
         fetch_map = {
             "yf": "scripts/fetch/fetch_yf_data.py",
             "mt5": "scripts/fetch/fetch_mt5_data.py",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,35 @@
+import sys
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import main as entry_main
+
+
+def test_default_fetcher_loaded(tmp_path):
+    cfg = {
+        "fetch_type": "yf",
+        "fetch_script": None,
+        "send_script": "scripts/send_api/send_to_gpt.py",
+        "parse_script": "scripts/parse_response/parse_gpt_response.py",
+        "response": "resp.txt",
+        "skip_fetch": False,
+        "skip_send": True,
+        "skip_parse": True,
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    called = {}
+
+    async def fake_run(step, script, *args):
+        called[step] = script
+
+    with patch.object(sys, "argv", ["main.py", "--config", str(cfg_path), "--skip-send", "--skip-parse"]), patch("main._run_step", fake_run):
+        asyncio.run(entry_main())
+
+    assert str(called["fetch"]).endswith("scripts/fetch/fetch_yf_data.py")


### PR DESCRIPTION
## Summary
- use `null` in config for the default `fetch_script`
- load built-in fetchers when `fetch_script` is empty or `None`
- add regression test for `main.py` default fetcher logic

## Testing
- `pytest -q tests/test_main.py::test_default_fetcher_loaded -vv`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851492002f083209c7dc01415f8cb25