### PR TITLE
Refactor main config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ python main.py
 
 `main.py` reads default settings from `config/main.json`. Pass `--config` with a
 different path to use custom values. Command-line options override the config
-entries. The file can also include nested dictionaries named `fetch_config`,
-`send_config` and `parse_config`. When present these sections are passed to the
-respective scripts so all parameters can be managed in one place.
+entries. The configuration is divided into `workflow`, `fetch`, `send` and
+`parse` sections so all parameters can be managed in one place.
 
 The `main.py` helper runs the fetch step, sends the result to the GPT API and
 parses the raw response into a JSON signal. Use `--fetch-script`, `--send-script`

--- a/config/main.json
+++ b/config/main.json
@@ -1,13 +1,19 @@
 {
-  "fetch_type": "yf",
-  "fetch_script": null,
-  "send_script": "scripts/send_api/send_to_gpt.py",
-  "parse_script": "scripts/parse_response/parse_gpt_response.py",
-  "response": "data/signals/latest_response.txt",
-  "skip_fetch": false,
-  "skip_send": false,
-  "skip_parse": false,
-  "fetch_config": {
+  "workflow": {
+    "fetch_type": "yf",
+    "scripts": {
+      "fetch": null,
+      "send": "scripts/send_api/send_to_gpt.py",
+      "parse": "scripts/parse_response/parse_gpt_response.py"
+    },
+    "response": "data/signals/latest_response.txt",
+    "skip": {
+      "fetch": false,
+      "send": false,
+      "parse": false
+    }
+  },
+  "fetch": {
     "tz_shift": 7,
     "symbol": "GC=F",
     "fetch_bars": 30,
@@ -18,14 +24,14 @@
       {"tf": "H1", "keep": 4}
     ]
   },
-  "send_config": {
+  "send": {
     "openai_api_key": "YOUR_API_KEY",
     "model": "gpt-4o",
     "csv_file": "",
     "csv_path": "data/fetch",
     "save_prompt_dir": "data/save_prompt_api"
   },
-  "parse_config": {
+  "parse": {
     "path_signals_csv": "data/signals/signals_csv",
     "file_signal_report": "csv_signal_report.csv",
     "path_signals_json": "data/signals/signals_json",

--- a/docs/config_main_th.md
+++ b/docs/config_main_th.md
@@ -4,29 +4,45 @@
 เรียกขั้นตอนการดึงข้อมูล ส่งข้อมูลไป GPT และแปลงผลลัพธ์เป็นไฟล์สัญญาณ
 โดยสามารถปรับแต่งค่าต่าง ๆ ได้ดังนี้
 
-| คีย์ | คำอธิบาย |
-|------|-----------|
-| `fetch_type` | กำหนดประเภทตัวดึงข้อมูลอัตโนมัติ ระบุ `yf` (Yahoo Finance) หรือ `mt5` |
-| `fetch_script` | พาธไปยังสคริปต์ดึงข้อมูลเอง หากระบุค่านี้จะไม่ใช้ `fetch_type` |
-| `send_script` | พาธสคริปต์ส่งข้อมูลไปยัง GPT API |
-| `parse_script` | พาธสคริปต์แปลงผลลัพธ์จาก GPT |
-| `response` | ไฟล์เก็บข้อความตอบกลับดิบจาก GPT ชั่วคราว |
-| `skip_fetch` | ตั้งค่าเป็น `true` เพื่อข้ามขั้นตอนดึงข้อมูล |
-| `skip_send` | ตั้งค่าเป็น `true` เพื่อข้ามการส่งข้อมูลไป GPT |
-| `skip_parse` | ตั้งค่าเป็น `true` เพื่อข้ามการแปลงผลลัพธ์ |
+โครงสร้างไฟล์แบ่งออกเป็นหมวดหมู่ดังนี้
 
-ตัวอย่างเนื้อหาเริ่มต้นในไฟล์มีดังนี้:
+| หมวด | คีย์ย่อย | คำอธิบาย |
+|------|---------|-----------|
+| `workflow.fetch_type` |  | กำหนดประเภทตัวดึงข้อมูลอัตโนมัติ (`yf` หรือ `mt5`) |
+| `workflow.scripts.fetch` |  | พาธสคริปต์ดึงข้อมูล (ไม่ระบุเพื่อใช้ตัวในระบบ) |
+| `workflow.scripts.send` |  | พาธสคริปต์ส่งข้อมูลไป GPT |
+| `workflow.scripts.parse` |  | พาธสคริปต์แปลงผลลัพธ์จาก GPT |
+| `workflow.response` |  | ไฟล์เก็บข้อความตอบกลับดิบจาก GPT |
+| `workflow.skip.fetch` |  | ตั้งค่า `true` เพื่อข้ามขั้นตอนดึงข้อมูล |
+| `workflow.skip.send` |  | ตั้งค่า `true` เพื่อข้ามการส่งข้อมูล |
+| `workflow.skip.parse` |  | ตั้งค่า `true` เพื่อข้ามการแปลงผลลัพธ์ |
+| `fetch` |  | คอนฟิกสำหรับขั้นตอนดึงข้อมูล |
+| `send` |  | คอนฟิกสำหรับขั้นตอนส่งข้อมูลไป GPT |
+| `parse` |  | คอนฟิกสำหรับขั้นตอนแปลงผลลัพธ์ |
+
+ตัวอย่างโครงสร้างไฟล์:
 
 ```json
 {
-  "fetch_type": "yf",
-  "fetch_script": null,
-  "send_script": "scripts/send_api/send_to_gpt.py",
-  "parse_script": "scripts/parse_response/parse_gpt_response.py",
-  "response": "data/signals/latest_response.txt",
-  "skip_fetch": false,
-  "skip_send": false,
-  "skip_parse": false
+  "workflow": {
+    "fetch_type": "yf",
+    "scripts": {
+      "fetch": null,
+      "send": "scripts/send_api/send_to_gpt.py",
+      "parse": "scripts/parse_response/parse_gpt_response.py"
+    },
+    "response": "data/signals/latest_response.txt",
+    "skip": {"fetch": false, "send": false, "parse": false}
+  },
+  "fetch": {
+    "symbol": "GC=F"
+  },
+  "send": {
+    "openai_api_key": "YOUR_API_KEY"
+  },
+  "parse": {
+    "tz_shift": 7
+  }
 }
 ```
 

--- a/main.py
+++ b/main.py
@@ -48,57 +48,61 @@ async def main() -> None:
         description="Fetch data, send to GPT and parse the response sequentially",
         parents=[pre_parser],
     )
+    workflow = config.get("workflow", {})
+    scripts_cfg = workflow.get("scripts", {})
+    skip_cfg = workflow.get("skip", {})
+
     parser.add_argument(
         "--fetch-type",
         choices=["yf", "mt5"],
-        default=config.get("fetch_type", "yf"),
+        default=workflow.get("fetch_type", "yf"),
         help="Select built-in data fetcher (ignored if --fetch-script is set)",
     )
     parser.add_argument(
         "--fetch-script",
-        default=config.get("fetch_script"),
+        default=scripts_cfg.get("fetch"),
         help="Path to data fetching script (overrides --fetch-type)",
     )
     parser.add_argument(
         "--send-script",
-        default=config.get("send_script", "scripts/send_api/send_to_gpt.py"),
+        default=scripts_cfg.get("send", "scripts/send_api/send_to_gpt.py"),
         help="Path to GPT API script",
     )
     parser.add_argument(
         "--parse-script",
-        default=config.get(
-            "parse_script", "scripts/parse_response/parse_gpt_response.py"
+        default=scripts_cfg.get(
+            "parse", "scripts/parse_response/parse_gpt_response.py"
         ),
         help="Path to response parsing script",
     )
     parser.add_argument(
         "--response",
-        default=config.get("response", "data/signals/latest_response.txt"),
+        default=workflow.get("response", "data/signals/latest_response.txt"),
         help="Temporary file to store raw GPT response",
     )
     parser.add_argument(
         "--skip-fetch",
         action="store_true",
-        default=bool(config.get("skip_fetch", False)),
+        default=bool(skip_cfg.get("fetch", False)),
         help="Skip the data fetching step",
     )
     parser.add_argument(
         "--skip-send",
         action="store_true",
-        default=bool(config.get("skip_send", False)),
+        default=bool(skip_cfg.get("send", False)),
         help="Skip sending data to GPT",
     )
     parser.add_argument(
         "--skip-parse",
         action="store_true",
-        default=bool(config.get("skip_parse", False)),
+        default=bool(skip_cfg.get("parse", False)),
         help="Skip parsing the GPT response",
     )
     args = parser.parse_args(remaining)
 
-    fetch_cfg = config.get("fetch_config")
-    send_cfg = config.get("send_config")
-    parse_cfg = config.get("parse_config")
+    fetch_cfg = config.get("fetch")
+    send_cfg = config.get("send")
+    parse_cfg = config.get("parse")
 
     if not args.fetch_script:
         fetch_map = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,15 +12,17 @@ from main import main as entry_main
 
 def test_default_fetcher_loaded(tmp_path):
     cfg = {
-        "fetch_type": "yf",
-        "fetch_script": None,
-        "send_script": "scripts/send_api/send_to_gpt.py",
-        "parse_script": "scripts/parse_response/parse_gpt_response.py",
-        "response": "resp.txt",
-        "skip_fetch": False,
-        "skip_send": True,
-        "skip_parse": True,
-        "fetch_config": {"symbol": "TEST"},
+        "workflow": {
+            "fetch_type": "yf",
+            "scripts": {
+                "fetch": None,
+                "send": "scripts/send_api/send_to_gpt.py",
+                "parse": "scripts/parse_response/parse_gpt_response.py",
+            },
+            "response": "resp.txt",
+            "skip": {"fetch": False, "send": True, "parse": True},
+        },
+        "fetch": {"symbol": "TEST"},
     }
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text(json.dumps(cfg))
@@ -30,7 +32,11 @@ def test_default_fetcher_loaded(tmp_path):
     async def fake_run(step, script, *args):
         called[step] = (script, args)
 
-    with patch.object(sys, "argv", ["main.py", "--config", str(cfg_path), "--skip-send", "--skip-parse"]), patch("main._run_step", fake_run):
+    with patch.object(
+        sys,
+        "argv",
+        ["main.py", "--config", str(cfg_path), "--skip-send", "--skip-parse"],
+    ), patch("main._run_step", fake_run):
         asyncio.run(entry_main())
 
     fetch_script, fetch_args = called["fetch"]


### PR DESCRIPTION
## Summary
- restructure `config/main.json` with clearer categories
- adapt `main.py` and tests to new keys
- update README and Thai documentation to describe new layout

## Testing
- `black main.py tests/test_main.py`
- `pytest -q tests/test_main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_685152dc381083208125ea3fac476987