### PR TITLE
Switch default fetcher to MT5

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ entries. The configuration is divided into `workflow`, `fetch`, `send` and
 The `main.py` helper runs the fetch step, sends the result to the GPT API and
 parses the raw response into a JSON signal. Use `--fetch-script`, `--send-script`
 and `--parse-script` to override the default script locations. You can also
-select a built-in fetcher with `--fetch-type yf|mt5` (default is `yf`) or skip
+select a built-in fetcher with `--fetch-type mt5|yf` (default is `mt5`) or skip
 individual stages with `--skip-fetch`, `--skip-send` and `--skip-parse`.
 
 Example fetching from MT5 and only parsing a previous response:

--- a/config/main.json
+++ b/config/main.json
@@ -1,6 +1,6 @@
 {
   "workflow": {
-    "fetch_type": "yf",
+    "fetch_type": "mt5",
     "scripts": {
       "fetch": null,
       "send": "scripts/send_api/send_to_gpt.py",
@@ -15,7 +15,7 @@
   },
   "fetch": {
     "tz_shift": 7,
-    "symbol": "GC=F",
+    "symbol": "XAUUSD",
     "fetch_bars": 30,
     "save_as_path": "data/fetch",
     "timeframes": [

--- a/docs/config_main_th.md
+++ b/docs/config_main_th.md
@@ -25,7 +25,7 @@
 ```json
 {
   "workflow": {
-    "fetch_type": "yf",
+    "fetch_type": "mt5",
     "scripts": {
       "fetch": null,
       "send": "scripts/send_api/send_to_gpt.py",
@@ -35,7 +35,7 @@
     "skip": {"fetch": false, "send": false, "parse": false}
   },
   "fetch": {
-    "symbol": "GC=F"
+    "symbol": "XAUUSD"
   },
   "send": {
     "openai_api_key": "YOUR_API_KEY"

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ async def main() -> None:
     parser.add_argument(
         "--fetch-type",
         choices=["yf", "mt5"],
-        default=workflow.get("fetch_type", "yf"),
+        default=workflow.get("fetch_type", "mt5"),
         help="Select built-in data fetcher (ignored if --fetch-script is set)",
     )
     parser.add_argument(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,7 @@ from main import main as entry_main
 def test_default_fetcher_loaded(tmp_path):
     cfg = {
         "workflow": {
-            "fetch_type": "yf",
+            "fetch_type": "mt5",
             "scripts": {
                 "fetch": None,
                 "send": "scripts/send_api/send_to_gpt.py",
@@ -40,5 +40,5 @@ def test_default_fetcher_loaded(tmp_path):
         asyncio.run(entry_main())
 
     fetch_script, fetch_args = called["fetch"]
-    assert str(fetch_script).endswith("scripts/fetch/fetch_yf_data.py")
+    assert str(fetch_script).endswith("scripts/fetch/fetch_mt5_data.py")
     assert "--config" in fetch_args


### PR DESCRIPTION
## Summary
- default workflow fetcher is now MT5
- update example configs and docs for MT5
- adjust README instructions
- update tests for new default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851565d948c8320aafc2a5efafe0c02