### PR TITLE
Fix outdated paths after live_trade restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,13 @@ __pycache__/
 logs/
 
 # Ignore signal data but keep directory structure
-data/signals/
-!data/signals/**
+live_trade/data/signals/
+!live_trade/data/signals/**
 
 # Ignore fetched CSV data
-data/fetch/*
-!data/fetch/.gitkeep
+live_trade/data/fetch/*
+!live_trade/data/fetch/.gitkeep
 gpt.json
 
 # Local settings
-config/setting_main.json
+live_trade/config/setting_main.json

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project requires the OpenAI Python library version 1.0 or newer.
 
 ## Directory Structure
 
-- `data/` – stores all CSV and JSON output
+- `live_trade/data/` – stores all CSV and JSON output
   - `fetch/` – fetched OHLC data
   - `signals/signals_json/` – stored trading signals in JSON format
   - `signals/signals_csv/` – CSV log of parsed signals
@@ -48,7 +48,7 @@ always applied *after* the raw data has been fetched so the CSV output uses the
 same timezone regardless of whether the source is MT5 or Yahoo Finance.
 
 If you do not specify an output path, `fetch_mt5_data.py` automatically
-saves to `data/fetch/` with a unique filename in the form
+saves to `live_trade/data/fetch/` with a unique filename in the form
 `<symbol>_<ddmmyy>_<HH>H.csv` (e.g. `xauusd_250616_16H.csv`).
 
 Example `scripts/fetch/config/fetch_mt5.json`:
@@ -67,7 +67,7 @@ Example `scripts/fetch/config/fetch_mt5.json`:
 }
 ```
 
-The `fetch` section inside `config/setting_main.json` accepts the same keys as the
+The `fetch` section inside `live_trade/config/setting_main.json` accepts the same keys as the
 individual fetcher configuration files, so you can provide `time_fetch` there as
 well when running the combined workflow with `main.py`.
 
@@ -90,8 +90,8 @@ Example `scripts/send_api/config/gpt.json`:
   "openai_api_key": "YOUR_API_KEY",
   "model": "gpt-4o",
   "csv_file": "",
-  "csv_path": "data/fetch",
-  "save_prompt_dir": "data/save_prompt_api"
+  "csv_path": "live_trade/data/fetch",
+  "save_prompt_dir": "live_trade/data/save_prompt_api"
 }
 ```
 
@@ -106,7 +106,7 @@ unless an absolute path is given.
 If you omit the positional `csv` argument, `send_to_gpt.py` uses the config
 values described above. The `--data-dir` option defaults to `csv_path` and can
 be used to override the search directory. The script also saves a copy of the
-CSV data and the final prompt to `data/save_prompt_api` by default. Use
+CSV data and the final prompt to `live_trade/data/save_prompt_api` by default. Use
 `--save-dir` or the `save_prompt_dir` config value to change this location.
 
 The parser `scripts/parse_response/parse_gpt_response.py` reads a raw GPT reply and writes the structured result to a JSON file. Default paths are loaded from `scripts/parse_response/config/parse.json` which defines where to store the CSV log, JSON signals and the latest response file. Use `--csv-log`, `--json-dir`, `--latest-response` or `--tz-shift` to override these values. Each run appends a row to the CSV log and saves the parsed data in a uniquely named file like `250616_153045.json` inside the configured directory.
@@ -120,7 +120,7 @@ a single command:
 python main.py
 ```
 
-`main.py` reads default settings from `config/setting_main.json`. Pass `--config` with a
+`main.py` reads default settings from `live_trade/config/setting_main.json`. Pass `--config` with a
 different path to use custom values. Command-line options override the config
 entries. The configuration is divided into `workflow`, `fetch`, `send` and
 `parse` sections so all parameters can be managed in one place.
@@ -142,7 +142,7 @@ python main.py --fetch-type mt5 --skip-fetch --skip-send
 The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled
 with **MetaEditor**. The indicator calculates RSI‑14, SMA‑20 and ATR‑14 for the
 current chart timeframe. If the `DisplaySignals` parameter is enabled it reads
-the latest JSON file from the `data/signals/signals_json/` directory and shows the parsed values
+the latest JSON file from the `live_trade/data/signals/signals_json/` directory and shows the parsed values
 on the chart. Each JSON signal must include the fields `signal_id`, `entry`, `sl`,
 `tp`, `pending_order_type` and `confidence`.
 

--- a/live_trade/config/setting_main.example.json
+++ b/live_trade/config/setting_main.example.json
@@ -6,7 +6,7 @@
       "send": "scripts/send_api/send_to_gpt.py",
       "parse": "scripts/parse_response/parse_gpt_response.py"
     },
-    "response": "data/signals/latest_response.txt",
+    "response": "live_trade/data/signals/latest_response.txt",
     "skip": {
       "fetch": false,
       "send": false,
@@ -18,7 +18,7 @@
     "symbol": "XAUUSD",
     "fetch_bars": 30,
     "time_fetch": "",
-    "save_as_path": "data/fetch",
+    "save_as_path": "live_trade/data/fetch",
     "timeframes": [
       {"tf": "M5", "keep": 10},
       {"tf": "M15", "keep": 6},
@@ -29,14 +29,14 @@
     "openai_api_key": "YOUR_API_KEY",
     "model": "gpt-4o",
     "csv_file": "",
-    "csv_path": "data/fetch",
-    "save_prompt_dir": "data/save_prompt_api"
+    "csv_path": "live_trade/data/fetch",
+    "save_prompt_dir": "live_trade/data/save_prompt_api"
   },
   "parse": {
-    "path_signals_csv": "data/signals/signals_csv",
+    "path_signals_csv": "live_trade/data/signals/signals_csv",
     "file_signal_report": "csv_signal_report.csv",
-    "path_signals_json": "data/signals/signals_json",
-    "path_latest_response": "data/signals/latest_response.txt",
+    "path_signals_json": "live_trade/data/signals/signals_json",
+    "path_latest_response": "live_trade/data/signals/latest_response.txt",
     "tz_shift": 4
   }
 }

--- a/live_trade/docs/config_main_th.md
+++ b/live_trade/docs/config_main_th.md
@@ -1,6 +1,6 @@
-# คู่มือการใช้งาน `config/setting_main.json`
+# คู่มือการใช้งาน `live_trade/config/setting_main.json`
 
-ไฟล์ `config/setting_main.json` ใช้กำหนดค่าสำหรับรันสคริปต์ `main.py` ซึ่งทำหน้าที่
+ไฟล์ `live_trade/config/setting_main.json` ใช้กำหนดค่าสำหรับรันสคริปต์ `main.py` ซึ่งทำหน้าที่
 เรียกขั้นตอนการดึงข้อมูล ส่งข้อมูลไป GPT และแปลงผลลัพธ์เป็นไฟล์สัญญาณ
 โดยสามารถปรับแต่งค่าต่าง ๆ ได้ดังนี้
 
@@ -31,7 +31,7 @@
       "send": "scripts/send_api/send_to_gpt.py",
       "parse": "scripts/parse_response/parse_gpt_response.py"
     },
-    "response": "data/signals/latest_response.txt",
+    "response": "live_trade/data/signals/latest_response.txt",
     "skip": {"fetch": false, "send": false, "parse": false}
   },
   "fetch": {

--- a/main.py
+++ b/main.py
@@ -32,7 +32,12 @@ def _load_config(path: Path) -> dict:
 
 async def main() -> None:
     pre_parser = argparse.ArgumentParser(add_help=False)
-    default_cfg = Path(__file__).resolve().parent / "config" / "setting_main.json"
+    default_cfg = (
+        Path(__file__).resolve().parent
+        / "live_trade"
+        / "config"
+        / "setting_main.json"
+    )
     pre_parser.add_argument(
         "--config", help="Path to JSON config", default=str(default_cfg)
     )
@@ -77,7 +82,9 @@ async def main() -> None:
     )
     parser.add_argument(
         "--response",
-        default=workflow.get("response", "data/signals/latest_response.txt"),
+        default=workflow.get(
+            "response", "live_trade/data/signals/latest_response.txt"
+        ),
         help="Temporary file to store raw GPT response",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- document new `live_trade/data` directory in README
- adjust config paths in docs and examples
- update `.gitignore` and default config path
- fix default locations in `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685237a01d308320b7179ec32a5b4fef