### PR TITLE
Use JsonParser for MT5 signal JSON

### DIFF
--- a/live_trade/ea/CustomIndicator.mq5
+++ b/live_trade/ea/CustomIndicator.mq5
@@ -3,6 +3,7 @@
 #property indicator_plots   3
 
 #include <stdlib.mqh>
+#include "JsonParser.mqh"
 
 #property indicator_label1 "RSI14"
 #property indicator_type1   DRAW_LINE
@@ -189,24 +190,14 @@ bool LoadLatestSignal()
 
 void ParseSignal(string json, SignalData &sig)
   {
-   sig.id = GetValue(json,"signal_id");
-   sig.entry = StringToDouble(GetValue(json,"entry"));
-   sig.sl = StringToDouble(GetValue(json,"sl"));
-   sig.tp = StringToDouble(GetValue(json,"tp"));
-   sig.order_type = GetValue(json,"pending_order_type");
-   sig.confidence = StringToDouble(GetValue(json,"confidence"));
-  }
+   JsonParser parser;
+   if(!parser.Parse(json))
+      return;
 
-string GetValue(string text,string key)
-  {
-   string pattern = "\""+key+"\"";
-   int pos = StringFind(text,pattern);
-   if(pos==-1) return "";
-   pos = StringFind(text,":",pos);
-   if(pos==-1) return "";
-   pos++;
-   while(pos<StringLen(text) && (text[pos]==' ' || text[pos]=='\"')) pos++;
-   int end=pos;
-   while(end<StringLen(text) && text[end]!='\"' && text[end]!=',' && text[end]!='}' && text[end]!='\n' && text[end]!='\r') end++;
-   return StringSubstr(text,pos,end-pos);
+   sig.id         = parser.GetString("signal_id");
+   sig.entry      = parser.GetDouble("entry");
+   sig.sl         = parser.GetDouble("sl");
+   sig.tp         = parser.GetDouble("tp");
+   sig.order_type = parser.GetString("pending_order_type");
+   sig.confidence = parser.GetDouble("confidence");
   }

--- a/live_trade/ea/JsonParser.mqh
+++ b/live_trade/ea/JsonParser.mqh
@@ -1,0 +1,54 @@
+#ifndef JSON_PARSER_MQH
+#define JSON_PARSER_MQH
+
+#include <stdlib.mqh>
+
+class JsonParser
+  {
+private:
+   string m_text;
+public:
+   bool Parse(const string text)
+     {
+      m_text=text;
+      return(true);
+     }
+
+   string GetString(const string key) const
+     {
+      string pattern="\""+key+"\"";
+      int pos=StringFind(m_text,pattern);
+      if(pos==-1) return "";
+      pos=StringFind(m_text,":",pos);
+      if(pos==-1) return "";
+      pos++;
+      bool quoted=false;
+      while(pos<StringLen(m_text) && (m_text[pos]==' ' || m_text[pos]=='\"'))
+        {
+         if(m_text[pos]=='\"')
+           {
+            quoted=true;
+            pos++;
+            break;
+           }
+         pos++;
+        }
+      int end=pos;
+      if(quoted)
+        {
+         end=StringFind(m_text,"\"",pos);
+         if(end==-1) end=StringLen(m_text);
+         return StringSubstr(m_text,pos,end-pos);
+        }
+      while(end<StringLen(m_text) && m_text[end]!=',' && m_text[end]!='}' && m_text[end]!=' ' && m_text[end]!='\n' && m_text[end]!='\r')
+         end++;
+      return StringSubstr(m_text,pos,end-pos);
+     }
+
+   double GetDouble(const string key) const
+     {
+      return StringToDouble(GetString(key));
+     }
+  };
+
+#endif // JSON_PARSER_MQH


### PR DESCRIPTION
## Summary
- add a minimal `JsonParser.mqh` implementation
- include and use JsonParser in `CustomIndicator.mq5`
- remove the old ad‑hoc GetValue logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68523b3408c0832096a6fc7392f4e3fa