### PR TITLE
Add APScheduler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ Example fetching from MT5 and only parsing a previous response:
 python main.py --fetch-type mt5 --skip-fetch --skip-send
 ```
 
+### Automated execution
+
+Run `scripts/scheduler_example.py` to execute the workflow once per hour. The
+script uses APScheduler to call `main.py` on a schedule:
+
+```bash
+python scripts/scheduler_example.py
+```
+
+Press **Ctrl+C** to stop the scheduler.
+
 ## CustomIndicator
 
 The `ea/CustomIndicator.mq5` file is a simple MT5 indicator that can be compiled

--- a/scripts/scheduler_example.py
+++ b/scripts/scheduler_example.py
@@ -1,0 +1,38 @@
+"""Example scheduler that runs main.py every hour."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from main import main as run_main
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _run_workflow() -> None:
+    """Execute the main workflow once."""
+    LOGGER.info("Starting scheduled workflow run")
+    try:
+        asyncio.run(run_main())
+    except SystemExit as exc:
+        LOGGER.error("main.py exited with code %s", exc.code)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error("main.py failed: %s", exc)
+
+
+def main() -> None:
+    """Configure and start the hourly scheduler."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    scheduler = BlockingScheduler()
+    scheduler.add_job(_run_workflow, "interval", hours=1)
+    LOGGER.info("Scheduler started; press Ctrl+C to exit")
+    try:
+        scheduler.start()
+    except (KeyboardInterrupt, SystemExit):  # pragma: no cover - manual stop
+        LOGGER.info("Scheduler stopped")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/scheduler_example.py` to run `main.py` every hour
- document scheduler usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852415199c88320b71e6243887faea4