### PR TITLE
Improve JSON extraction logic

### DIFF
--- a/scripts/parse_response/parse_gpt_response.py
+++ b/scripts/parse_response/parse_gpt_response.py
@@ -40,12 +40,15 @@ def _extract_json(text: str) -> dict:
     if fence:
         text = fence.group(1)
 
-    # Use a non-greedy pattern so additional text or JSON blocks after the
-    # first one do not get included in the match.
-    match = re.search(r"{.*?}", text, flags=re.DOTALL)
-    if not match:
+    decoder = json.JSONDecoder()
+    start = text.find("{")
+    if start == -1:
         raise ValueError("No JSON object found in response")
-    return json.loads(match.group(0))
+    try:
+        obj, _ = decoder.raw_decode(text[start:])
+    except json.JSONDecodeError as exc:  # noqa: FBT001
+        raise ValueError(f"Invalid JSON object: {exc}") from exc
+    return obj
 
 
 def _timestamp_code(ts: datetime) -> str:

--- a/tests/test_parse_gpt_response.py
+++ b/tests/test_parse_gpt_response.py
@@ -31,3 +31,8 @@ def test_extract_json_missing():
 def test_extract_json_multiple_objects():
     text = "first {\"a\": 1} second {\"b\": 2}"
     assert _extract_json(text) == {"a": 1}
+
+
+def test_extract_json_nested_objects():
+    text = "```json\n{\"a\": {\"b\": 2}}\n```"
+    assert _extract_json(text) == {"a": {"b": 2}}


### PR DESCRIPTION
## Summary
- parse GPT responses with `json.JSONDecoder().raw_decode`
- test nested JSON objects for extraction

## Testing
- `pytest -q tests/test_parse_gpt_response.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685244a9267c83208aace119e165e153