### PR TITLE
Add pointer to Thai usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ cp live_trade/config/setting_main.example.json \
 See [`live_trade/docs/config_main_th.md`](live_trade/docs/config_main_th.md) for
 an explanation of each key.
 
+For Thai users: สำหรับภาษาไทย ดูเอกสารที่ `live_trade/docs/usage_th.md`.
+
 ## Running the complete workflow
 
 Once the individual scripts are configured you can execute the whole process in


### PR DESCRIPTION
## Summary
- mention the Thai usage manual near the configuration section

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685247e5d5048320950ccdacbc77dddb