### PR TITLE
Run helper scripts as modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,8 +13,25 @@ from pathlib import Path
 
 
 async def _run_step(step: str, script: Path, *args: str) -> None:
-    """Run a script as a subprocess and wait for it to finish."""
-    cmd = [sys.executable, str(script), *args]
+    """Run a script as a subprocess and wait for it to finish.
+
+    If *script* points to a Python file, run it as a module so the project
+    root is on ``sys.path``. Otherwise fall back to executing the file
+    directly with the current Python interpreter.
+    """
+    if script.suffix == ".py":
+        try:
+            module = ".".join(
+                script.with_suffix("")
+                .resolve()
+                .relative_to(Path(__file__).resolve().parent)
+                .parts
+            )
+        except ValueError:
+            module = ".".join(script.with_suffix("").parts)
+        cmd = [sys.executable, "-m", module, *args]
+    else:
+        cmd = [sys.executable, str(script), *args]
     logging.info("Running %s: %s", step, " ".join(cmd))
     proc = await asyncio.create_subprocess_exec(*cmd)
     await proc.communicate()

--- a/tests/test_run_step.py
+++ b/tests/test_run_step.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import _run_step
+
+
+class DummyProc:
+    def __init__(self):
+        self.returncode = 0
+
+    async def communicate(self):
+        pass
+
+
+def _fake_exec(*cmd):
+    _fake_exec.called = cmd
+    return DummyProc()
+
+
+def test_run_step_py_module():
+    script = Path("scripts/fetch/fetch_mt5_data.py")
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        asyncio.run(_run_step("fetch", script, "--foo"))
+    assert _fake_exec.called[0] == sys.executable
+    assert _fake_exec.called[1] == "-m"
+    assert _fake_exec.called[2].endswith("scripts.fetch.fetch_mt5_data")
+    assert _fake_exec.called[3:] == ("--foo",)
+
+
+def test_run_step_non_py():
+    script = Path("scripts/install_deps.sh")
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        asyncio.run(_run_step("install", script, "arg"))
+    assert _fake_exec.called == (sys.executable, str(script), "arg")
+


### PR DESCRIPTION
## Summary
- run helper scripts with `python -m` when calling `.py` files
- add regression tests for `_run_step`

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68524cee4d1083209b2472a82ebbc55c