### PR TITLE
Fix gitignore data paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,16 @@ __pycache__/
 logs/
 
 # Ignore signal data but keep directory structure
-live_trade/data/signals/
-!live_trade/data/signals/**
+data/live_trade/signals/
+!data/live_trade/signals/**
 
 # Ignore fetched CSV data
-live_trade/data/fetch/*
-!live_trade/data/fetch/.gitkeep
+data/live_trade/fetch/*
+!data/live_trade/fetch/.gitkeep
+
+# Ignore backtest data
+data/back_test/*
+!data/back_test/.gitkeep
 gpt.json
 
 # Local settings


### PR DESCRIPTION
## Summary
- ignore `data/live_trade` and `data/back_test` instead of `live_trade/data`
- keep `.gitkeep` placeholders under new data directories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68525f6dbd008320bd7359cb5180a189