### PR TITLE
Add backtest loop and config

### DIFF
--- a/back_test/backtest.json
+++ b/back_test/backtest.json
@@ -7,11 +7,7 @@
       "parse": "scripts/parse_response/parse_gpt_response.py"
     },
     "response": "data/back_test/signals/latest_response.txt",
-    "skip": {
-      "fetch": false,
-      "send": false,
-      "parse": false
-    }
+    "skip": {"fetch": false, "send": false, "parse": false}
   },
   "fetch": {
     "tz_shift": 4,

--- a/back_test/main_backtest.py
+++ b/back_test/main_backtest.py
@@ -9,6 +9,7 @@ import json
 import tempfile
 import logging
 import sys
+from datetime import datetime, timedelta
 from pathlib import Path
 
 
@@ -95,7 +96,7 @@ async def main() -> None:
     parser.add_argument(
         "--response",
         default=workflow.get(
-            "response", "live_trade/data/signals/latest_response.txt"
+            "response", "data/back_test/signals/latest_response.txt"
         ),
         help="Temporary file to store raw GPT response",
     )
@@ -123,6 +124,13 @@ async def main() -> None:
     send_cfg = config.get("send")
     parse_cfg = config.get("parse")
 
+    start_time = datetime.fromisoformat(config.get("start_time"))
+    end_time = datetime.fromisoformat(config.get("end_time"))
+    step = timedelta(minutes=int(config.get("loop_every_minutes", 60)))
+    signal_table = Path(config.get(
+        "signal_table", "data/back_test/signals/backtest_signals.csv"
+    ))
+
     if not args.fetch_script:
         fetch_map = {
             "yf": "scripts/fetch/fetch_yf_data.py",
@@ -135,41 +143,54 @@ async def main() -> None:
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    if not args.skip_fetch:
-        if fetch_cfg:
-            with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
-                json.dump(fetch_cfg, tmp)
-            try:
-                await _run_step("fetch", Path(args.fetch_script), "--config", tmp.name)
-            finally:
-                Path(tmp.name).unlink(missing_ok=True)
-        else:
-            await _run_step("fetch", Path(args.fetch_script))
-    if not args.skip_send:
-        send_args = ["--output", args.response]
-        if send_cfg:
-            with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
-                json.dump(send_cfg, tmp)
-            send_args.extend(["--config", tmp.name])
-            try:
+    current = start_time
+    while current <= end_time:
+        logging.info("Backtest step at %s", current.isoformat())
+
+        step_fetch = fetch_cfg.copy() if fetch_cfg else None
+        if step_fetch is not None:
+            step_fetch["time_fetch"] = current.strftime("%Y-%m-%d %H:%M:%S")
+
+        step_parse = parse_cfg.copy() if parse_cfg else {}
+        step_parse["path_signals_csv"] = str(signal_table.parent)
+        step_parse["file_signal_report"] = signal_table.name
+
+        if not args.skip_fetch:
+            if step_fetch is not None:
+                with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
+                    json.dump(step_fetch, tmp)
+                try:
+                    await _run_step("fetch", Path(args.fetch_script), "--config", tmp.name)
+                finally:
+                    Path(tmp.name).unlink(missing_ok=True)
+            else:
+                await _run_step("fetch", Path(args.fetch_script))
+
+        if not args.skip_send:
+            send_args = ["--output", args.response]
+            if send_cfg:
+                with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
+                    json.dump(send_cfg, tmp)
+                send_args.extend(["--config", tmp.name])
+                try:
+                    await _run_step("send", Path(args.send_script), *send_args)
+                finally:
+                    Path(tmp.name).unlink(missing_ok=True)
+            else:
                 await _run_step("send", Path(args.send_script), *send_args)
-            finally:
-                Path(tmp.name).unlink(missing_ok=True)
-        else:
-            await _run_step("send", Path(args.send_script), *send_args)
-    if not args.skip_parse:
-        parse_args = []
-        if parse_cfg:
+
+        if not args.skip_parse:
+            parse_args = []
             with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
-                json.dump(parse_cfg, tmp)
+                json.dump(step_parse, tmp)
             parse_args.extend(["--config", tmp.name])
             parse_args.append(args.response)
             try:
                 await _run_step("parse", Path(args.parse_script), *parse_args)
             finally:
                 Path(tmp.name).unlink(missing_ok=True)
-        else:
-            await _run_step("parse", Path(args.parse_script), args.response)
+
+        current += step
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand backtest example config with loop parameters
- add sample `backtest.json`
- iterate over historical timestamps in `main_backtest.py`
- default responses now write to `data/back_test`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852612845308320987cfaebae6771a9