### PR TITLE
Fix config paths for main scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ gpt.json
 
 # Local settings
 live_trade/config/setting_main.json
+back_test/config/setting_main_backtest.json
+live_trade/config/setting_main_liveTrade.json

--- a/back_test/main_backtest.py
+++ b/back_test/main_backtest.py
@@ -50,7 +50,11 @@ def _load_config(path: Path) -> dict:
 
 async def main() -> None:
     pre_parser = argparse.ArgumentParser(add_help=False)
-    default_cfg = Path(__file__).resolve().parent / "config" / "setting_main.json"
+    default_cfg = (
+        Path(__file__).resolve().parent
+        / "config"
+        / "setting_main_backtest.json"
+    )
     pre_parser.add_argument(
         "--config", help="Path to JSON config", default=str(default_cfg)
     )

--- a/live_trade/main_liveTrade.py
+++ b/live_trade/main_liveTrade.py
@@ -49,7 +49,11 @@ def _load_config(path: Path) -> dict:
 
 async def main() -> None:
     pre_parser = argparse.ArgumentParser(add_help=False)
-    default_cfg = Path(__file__).resolve().parent / "config" / "setting_main.json"
+    default_cfg = (
+        Path(__file__).resolve().parent
+        / "config"
+        / "setting_main_liveTrade.json"
+    )
     pre_parser.add_argument(
         "--config", help="Path to JSON config", default=str(default_cfg)
     )


### PR DESCRIPTION
## Summary
- update default config paths in `main_backtest.py` and `main_liveTrade.py`
- ignore new config files in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `./scripts/install_deps.sh` *(fails due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_685275ae840c83209436b0af42ac5c51