### PR TITLE
refactor: share run step helper

### DIFF
--- a/back_test/main_backtest.py
+++ b/back_test/main_backtest.py
@@ -12,32 +12,7 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
-
-async def _run_step(step: str, script: Path, *args: str) -> None:
-    """Run a script as a subprocess and wait for it to finish.
-
-    If *script* points to a Python file, run it as a module so the project
-    root is on ``sys.path``. Otherwise fall back to executing the file
-    directly with the current Python interpreter.
-    """
-    if script.suffix == ".py":
-        try:
-            module = ".".join(
-                script.with_suffix("")
-                .resolve()
-                .relative_to(Path(__file__).resolve().parents[1])
-                .parts
-            )
-        except ValueError:
-            module = ".".join(script.with_suffix("").parts)
-        cmd = [sys.executable, "-m", module, *args]
-    else:
-        cmd = [sys.executable, str(script), *args]
-    logging.info("Running %s: %s", step, " ".join(cmd))
-    proc = await asyncio.create_subprocess_exec(*cmd)
-    await proc.communicate()
-    if proc.returncode:
-        raise RuntimeError(f"{step} failed with code {proc.returncode}")
+from scripts.common import _run_step
 
 
 def _load_config(path: Path) -> dict:

--- a/live_trade/main_liveTrade.py
+++ b/live_trade/main_liveTrade.py
@@ -11,32 +11,7 @@ import logging
 import sys
 from pathlib import Path
 
-
-async def _run_step(step: str, script: Path, *args: str) -> None:
-    """Run a script as a subprocess and wait for it to finish.
-
-    If *script* points to a Python file, run it as a module so the project
-    root is on ``sys.path``. Otherwise fall back to executing the file
-    directly with the current Python interpreter.
-    """
-    if script.suffix == ".py":
-        try:
-            module = ".".join(
-                script.with_suffix("")
-                .resolve()
-                .relative_to(Path(__file__).resolve().parents[1])
-                .parts
-            )
-        except ValueError:
-            module = ".".join(script.with_suffix("").parts)
-        cmd = [sys.executable, "-m", module, *args]
-    else:
-        cmd = [sys.executable, str(script), *args]
-    logging.info("Running %s: %s", step, " ".join(cmd))
-    proc = await asyncio.create_subprocess_exec(*cmd)
-    await proc.communicate()
-    if proc.returncode:
-        raise RuntimeError(f"{step} failed with code {proc.returncode}")
+from scripts.common import _run_step
 
 
 def _load_config(path: Path) -> dict:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,0 +1,37 @@
+"""Utility helpers used across project scripts."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+
+async def _run_step(step: str, script: Path, *args: str) -> None:
+    """Run a script as a subprocess and wait for it to finish.
+
+    If *script* points to a Python file, run it as a module so the project
+    root is on ``sys.path``. Otherwise fall back to executing the file
+    directly with the current Python interpreter.
+    """
+    if script.suffix == ".py":
+        try:
+            module = ".".join(
+                script.with_suffix("")
+                .resolve()
+                .relative_to(Path(__file__).resolve().parents[1])
+                .parts
+            )
+        except ValueError:
+            module = ".".join(script.with_suffix("").parts)
+        cmd = [sys.executable, "-m", module, *args]
+    else:
+        cmd = [sys.executable, str(script), *args]
+    logging.info("Running %s: %s", step, " ".join(cmd))
+    proc = await asyncio.create_subprocess_exec(*cmd)
+    await proc.communicate()
+    if proc.returncode:
+        raise RuntimeError(f"{step} failed with code {proc.returncode}")
+
+__all__ = ["_run_step"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,7 @@ def test_default_fetcher_loaded(tmp_path):
         sys,
         "argv",
         ["live_trade/main_liveTrade.py", "--config", str(cfg_path), "--skip-send", "--skip-parse"],
-    ), patch("live_trade.main_liveTrade._run_step", fake_run):
+    ), patch("scripts.common._run_step", fake_run):
         asyncio.run(entry_main())
 
     fetch_script, fetch_args = called["fetch"]
@@ -70,7 +70,7 @@ def test_time_fetch_passed(tmp_path):
         sys,
         "argv",
         ["live_trade/main_liveTrade.py", "--config", str(cfg_path), "--skip-send", "--skip-parse"],
-    ), patch("live_trade.main_liveTrade._run_step", fake_run):
+    ), patch("scripts.common._run_step", fake_run):
         asyncio.run(entry_main())
 
     assert recorded["fetch"]["time_fetch"] == "2024-01-01 00:00:00"

--- a/tests/test_run_step.py
+++ b/tests/test_run_step.py
@@ -6,7 +6,7 @@ import asyncio
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from live_trade.main_liveTrade import _run_step
+from scripts.common import _run_step
 
 
 class DummyProc:


### PR DESCRIPTION
## Summary
- centralize `_run_step` helper in `scripts/common.py`
- import from new module in live trading and backtesting
- update tests to reference the relocated helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685277ec1c9c8320a81fb7ec2c994098