### PR TITLE
Fix CLI import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ This project implements an automated trading workflow that uses data from MT5 an
 
 ## Installation
 
-Install the pinned Python dependencies using the helper script:
+Install the pinned Python dependencies using the helper script and make the
+`gpt_trader` package available:
 
 ```bash
 ./scripts/install_deps.sh
+pip install -e .
 ```
 
 This project requires specific versions of `pandas`, `MetaTrader5`, `openai` and
@@ -172,7 +174,7 @@ Once the individual scripts are configured you can execute the whole process in
 a single command:
 
 ```bash
-python src/gpt_trader/cli/main_liveTrade.py
+python -m gpt_trader.cli.main_liveTrade
 ```
 
 `main_liveTrade.py` reads default settings from `config/setting_live_trade.json` (the

--- a/docs/usage_overall_th.md
+++ b/docs/usage_overall_th.md
@@ -5,9 +5,10 @@
 
 ## 1. เตรียมสภาพแวดล้อม
 
-1. ติดตั้งไลบรารีทั้งหมดตามไฟล์ `requirements.txt`
+1. ติดตั้งไลบรารีทั้งหมดตามไฟล์ `requirements.txt` และติดตั้งแพ็กเกจ
    ```bash
    ./scripts/install_deps.sh
+   pip install -e .
    ```
 2. สร้างไฟล์คอนฟิกจากตัวอย่างในโฟลเดอร์ `config/`
    - `setting_live_trade.example.json`
@@ -21,7 +22,7 @@
 1. ตรวจสอบไฟล์ `config/setting_live_trade.json` ว่ากำหนดค่าถูกต้องแล้ว
 2. รันสคริปต์หลัก
    ```bash
-   python src/gpt_trader/cli/main_liveTrade.py
+   python -m gpt_trader.cli.main_liveTrade
    ```
    สามารถระบุอาร์กิวเมนต์เพิ่มเติมได้ เช่น `--config path/to/file.json`
    หรือ `--skip-fetch` เพื่อข้ามขั้นตอนดึงข้อมูล


### PR DESCRIPTION
## Summary
- clarify that `gpt_trader` must be installed to run the CLI
- add `pip install -e .` step in the setup docs
- document running the workflow via `python -m gpt_trader.cli.main_liveTrade`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685288b7890883208d1719d1bb18330a