### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [project]
 name = "gpt_trader"
 version = "0.0.0"
-packages = [{include = "gpt_trader", from = "src"}]
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
## Summary
- remove `[project].packages`
- add `[tool.setuptools.packages.find] where=['src']`

## Testing
- `pip install -e . --no-build-isolation`
- `python -c 'import gpt_trader, sys; print(gpt_trader.__file__)'`
- `python main_liveTrade.py --config config/setting_live_trade.example.json --help`

------
https://chatgpt.com/codex/tasks/task_e_685294319e9c83208075ba901372be18