### PR TITLE
Emphasize dependency script before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,15 +253,18 @@ Refer to `Work_flow.md` for the full workflow description.
 
 ## Running tests
 
-Install the pinned dependencies before executing the test suite:
+Install the pinned dependencies *before* executing the test suite. The tests
+import optional packages that will be missing in a fresh clone unless you run
+the helper script:
 
 ```bash
 ./scripts/install_deps.sh
 ```
 
 You can also install the packages listed in `requirements.txt` manually. The
-tests rely on optional modules such as `MetaTrader5`, `openai` and `yfinance` to
-run to completion.
+tests rely on optional modules such as `MetaTrader5`, `openai` and `yfinance`.
+If these modules are missing the test discovery step will raise a clear error
+from `tests/__init__.py`.
 
 Run the tests with:
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+"""Test package setup.
+
+This module checks that optional third-party dependencies are available. If any
+are missing a helpful message is raised so developers remember to install them
+before running the tests.
+"""
+
+REQUIRED = ["pandas", "MetaTrader5", "openai", "yfinance"]
+
+for mod in REQUIRED:
+    try:
+        __import__(mod)
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            f"Required package '{mod}' is missing. Run './scripts/install_deps.sh' before executing the tests."
+        ) from exc
+


### PR DESCRIPTION
## Summary
- note dependency install script in README
- warn about missing packages if tests are imported

## Testing
- `pytest -q` *(fails: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685294fe298c8320abd28b988dd16eec