### PR TITLE
Fix main_liveTrade import path

### DIFF
--- a/main_liveTrade.py
+++ b/main_liveTrade.py
@@ -11,6 +11,9 @@ import logging
 import sys
 from pathlib import Path
 
+repo_root = Path(__file__).resolve().parent
+sys.path.insert(0, str(repo_root / "src"))
+
 from gpt_trader.cli.common import _run_step
 
 


### PR DESCRIPTION
## Summary
- modify `main_liveTrade.py` to add the `src` directory to `sys.path`
- confirm the script runs without needing environment variables

## Testing
- `python main_liveTrade.py --config config/setting_live_trade.example.json --skip-fetch --skip-send --skip-parse`

------
https://chatgpt.com/codex/tasks/task_e_6852974765508320abfc7ff7c00c4ca0