### PR TITLE
Fix scheduler import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ python main_liveTrade.py --fetch-type mt5 --skip-fetch --skip-send
 ### Automated execution
 
 Run `src/gpt_trader/cli/scheduler_example.py` to execute the workflow once per hour. The
-script uses APScheduler to call `main_liveTrade.py` on a schedule:
+script uses APScheduler to call `main_liveTrade.py` on a schedule. Since
+`main_liveTrade.py` now prepends the repository root to `sys.path`, the
+scheduler can be executed directly from the project root:
 
 ```bash
 python src/gpt_trader/cli/scheduler_example.py

--- a/docs/usage_overall_th.md
+++ b/docs/usage_overall_th.md
@@ -26,7 +26,8 @@
    สามารถระบุอาร์กิวเมนต์เพิ่มเติมได้ เช่น `--config path/to/file.json`
    หรือ `--skip-fetch` เพื่อข้ามขั้นตอนดึงข้อมูล
 3. สำหรับการรันแบบอัตโนมัติ ให้เรียก `src/gpt_trader/cli/scheduler_example.py`
-   เพื่อทำงานทุกชั่วโมง
+   เพื่อทำงานทุกชั่วโมง สคริปต์นี้สามารถรันได้โดยตรง เพราะ
+   `main_liveTrade.py` จะเพิ่ม path ของโปรเจกต์ให้อัตโนมัติ
    ```bash
    python src/gpt_trader/cli/scheduler_example.py
    ```

--- a/src/gpt_trader/cli/main_liveTrade.py
+++ b/src/gpt_trader/cli/main_liveTrade.py
@@ -1,6 +1,13 @@
 """Wrapper to launch main_liveTrade from the repository root."""
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[2]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
 from main_liveTrade import main
 
 __all__ = ["main"]


### PR DESCRIPTION
## Summary
- ensure `main_liveTrade.py` can be loaded when calling scheduler directly
- document running `scheduler_example.py` in README and Thai usage guide

## Testing
- `python src/gpt_trader/cli/scheduler_example.py` *(fails: ModuleNotFoundError: No module named 'apscheduler')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68529e092edc8320bf6e2dd00547f87e