### PR TITLE
Add countdown to scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ scheduler can be executed directly from the project root:
 python src/gpt_trader/cli/scheduler_example.py
 ```
 
-Press **Ctrl+C** to stop the scheduler.
+The script prints a countdown showing how long remains until the next scheduled
+execution. Press **Ctrl+C** to stop the scheduler.
 
 ## Backtesting
 

--- a/src/gpt_trader/cli/scheduler_example.py
+++ b/src/gpt_trader/cli/scheduler_example.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 import logging
+import threading
+import time
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 
@@ -22,11 +25,38 @@ def _run_workflow() -> None:
         LOGGER.error("main_liveTrade.py failed: %s", exc)
 
 
+def _start_countdown(job) -> None:
+    """Display a simple countdown until *job* runs."""
+
+    def _loop() -> None:
+        while True:
+            next_run = job.next_run_time
+            if next_run is None:
+                time.sleep(1)
+                continue
+            while True:
+                remaining = next_run - datetime.now(next_run.tzinfo)
+                if remaining.total_seconds() <= 0:
+                    break
+                hours, rem = divmod(int(remaining.total_seconds()), 3600)
+                minutes, seconds = divmod(rem, 60)
+                print(
+                    f"Next run in {hours:02d}:{minutes:02d}:{seconds:02d}",
+                    end="\r",
+                    flush=True,
+                )
+                time.sleep(1)
+            time.sleep(1)
+
+    threading.Thread(target=_loop, daemon=True).start()
+
+
 def main() -> None:
     """Configure and start the hourly scheduler."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
     scheduler = BlockingScheduler()
-    scheduler.add_job(_run_workflow, "interval", hours=1)
+    job = scheduler.add_job(_run_workflow, "interval", hours=1)
+    _start_countdown(job)
     LOGGER.info("Scheduler started; press Ctrl+C to exit")
     try:
         scheduler.start()


### PR DESCRIPTION
## Summary
- show a countdown until the next run in `scheduler_example.py`
- mention countdown behaviour in the README

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852a05cf2c083209b50abefe4500ca1