### PR TITLE
Add APScheduler dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas==2.3.0
 MetaTrader5==5.0.5120
 openai==1.88.0
 yfinance==0.2.63
+APScheduler==3.10.4

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -2,3 +2,4 @@
 # Install pinned dependencies for development and testing
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
+python -m pip install APScheduler==3.10.4


### PR DESCRIPTION
## Summary
- pin APScheduler to version 3.10.4 in requirements
- install APScheduler in `scripts/install_deps.sh`

## Testing
- `sh scripts/install_deps.sh` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852a1b1b1d4832099428e3a8bd1a6d6