### PR TITLE
Update README with APScheduler notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Install the pinned Python dependencies using the helper script:
 
 This project requires specific versions of `pandas`, `MetaTrader5`, `openai` and
 `yfinance` which are defined in `requirements.txt`.
+`APScheduler` is also needed if you plan to use
+`src/gpt_trader/cli/scheduler_example.py`. The helper script above installs it
+automatically.
 
 ### Installing MetaTrader5
 
@@ -198,7 +201,9 @@ python main_liveTrade.py --fetch-type mt5 --skip-fetch --skip-send
 ### Automated execution
 
 Run `src/gpt_trader/cli/scheduler_example.py` to execute the workflow once per hour. The
-script uses APScheduler to call `main_liveTrade.py` on a schedule. Since
+script uses APScheduler to call `main_liveTrade.py` on a schedule. APScheduler
+version 3.x is expected but the code attempts to handle version 4.x as well.
+Since
 `main_liveTrade.py` now prepends the repository root to `sys.path`, the
 scheduler can be executed directly from the project root:
 


### PR DESCRIPTION
## Summary
- document APScheduler requirement for running the scheduler
- clarify that the code targets APScheduler 3.x but works with v4

## Testing
- `./scripts/install_deps.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852a2a8bdac8320a44b788da538861d