### PR TITLE
Add shared RiskUtils helper for lot sizing

### DIFF
--- a/live_trade/ea/LiveTradeEA.mq5
+++ b/live_trade/ea/LiveTradeEA.mq5
@@ -1,5 +1,6 @@
 #property strict
 #include <Trade/Trade.mqh>
+#include "RiskUtils.mqh"
 
 //+------------------------------------------------------------------+
 //| Expert Advisor to execute live trade signals from CSV             |
@@ -48,25 +49,7 @@ bool LoadLatestSignal(Signal &sig)
    return(true);
   }
 
-double ComputeRisk(double conf)
-  {
-   if(conf>80) return(0.05);
-   if(conf>70) return(0.03);
-   return(DefaultRisk);
-  }
 
-double CalcLot(double entry,double sl,double risk)
-  {
-   double distance=MathAbs(entry-sl);
-   if(distance<=0) return(0);
-   double tick_value=SymbolInfoDouble(_Symbol,SYMBOL_TRADE_TICK_VALUE);
-   double lots=(AccountInfoDouble(ACCOUNT_BALANCE)*risk)/(distance/_Point*tick_value);
-   double step=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_STEP);
-   double minv=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_MIN);
-   lots=MathMax(lots,minv);
-   lots=MathFloor(lots/step)*step;
-   return(lots);
-  }
 
 void OnTick()
   {
@@ -83,8 +66,7 @@ void OnTick()
       return;
    last_processed=sig.timestamp;
 
-   double risk=ComputeRisk(sig.conf);
-   double lot=CalcLot(sig.entry,sig.sl,risk);
+   double lot=CalcLot(sig.entry,sig.sl,sig.conf);
    if(lot<=0) return;
 
    MqlTradeRequest req; MqlTradeResult res;

--- a/live_trade/ea/RiskUtils.mqh
+++ b/live_trade/ea/RiskUtils.mqh
@@ -1,0 +1,27 @@
+#ifndef RISK_UTILS_MQH
+#define RISK_UTILS_MQH
+
+//+------------------------------------------------------------------+
+//| Calculate lot size from entry, sl and confidence                 |
+//| Uses DefaultRisk (input double) defined in the including EA      |
+//+------------------------------------------------------------------+
+inline double CalcLot(double entry,double sl,double confidence)
+  {
+   double risk=DefaultRisk;
+   if(confidence>80) risk=0.05;
+   else if(confidence>70) risk=0.03;
+
+   double distance=MathAbs(entry-sl);
+   if(distance<=0) return(0);
+
+   double tick_value=SymbolInfoDouble(_Symbol,SYMBOL_TRADE_TICK_VALUE);
+   double lots=(AccountInfoDouble(ACCOUNT_BALANCE)*risk)/(distance/_Point*tick_value);
+
+   double step=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_STEP);
+   double minv=SymbolInfoDouble(_Symbol,SYMBOL_VOLUME_MIN);
+   lots=MathMax(lots,minv);
+   lots=MathFloor(lots/step)*step;
+   return(lots);
+  }
+
+#endif // RISK_UTILS_MQH


### PR DESCRIPTION
## Summary
- add `RiskUtils.mqh` for reusable risk calculations
- include new helper in LiveTradeEA and BacktestEA

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68537dd6b7d8832092a382b00794f453