### PR TITLE
Fix scheduler entry for main_liveTrade

### DIFF
--- a/src/gpt_trader/cli/main_liveTrade.py
+++ b/src/gpt_trader/cli/main_liveTrade.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+"""Bridge module to run ``main_liveTrade`` from the package."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add repository root so the top-level module can be imported
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from main_liveTrade import main  # type: ignore  # noqa: E402
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- bridge main_liveTrade into the package so other modules can import it

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685382547cbc8320b82e63207214472c