### PR TITLE
Fix scheduler import

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -9,7 +9,14 @@ import time
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 
-from gpt_trader.cli.main_liveTrade import main as run_main
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from main_liveTrade import main as run_main
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- update scheduler to import main_liveTrade directly
- avoid circular import

## Testing
- `python src/gpt_trader/cli/scheduler_liveTrade.py` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_685387ec32a483208a813757fac15050