### PR TITLE
Fix scheduler import path

### DIFF
--- a/src/gpt_trader/cli/main_liveTrade.py
+++ b/src/gpt_trader/cli/main_liveTrade.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Add repository root so the top-level module can be imported
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -12,7 +12,7 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 from pathlib import Path
 import sys
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 


### PR DESCRIPTION
## Summary
- fix main_liveTrade wrapper to insert repo root in sys.path
- adjust scheduler to do the same

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685389021b188320a0f261a32d429812