### PR TITLE
Improve notification details

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,10 +89,11 @@ def test_notify_called(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_called()
+    assert "signal_id:id" in line_fn.call_args[0][0]
 
 
 def test_notify_line_only(tmp_path):
@@ -110,7 +111,7 @@ def test_notify_line_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_not_called()
@@ -131,7 +132,7 @@ def test_notify_telegram_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
         sched._run_workflow()
     line_fn.assert_not_called()
     tg_fn.assert_called()


### PR DESCRIPTION
## Summary
- include helper to load latest signal JSON
- append signal info to LINE/Telegram notifications
- adjust scheduler tests for new functionality

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853aad3cf308320a64e1737dd0631c4