### PR TITLE
Add configurable indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ using `--config`. The configuration defines:
 
 - `symbol` – trading pair (e.g., `XAUUSD`).
 - `fetch_bars` – number of historical bars requested for indicator calculation.
+- `indicators` – enable or disable calculation of `atr14`, `rsi14` and `sma20`.
 - `time_fetch` – optional timestamp in the form `YYYY-MM-DD HH:MM:SS` to
   retrieve bars ending at that time. Leave empty to fetch the most recent data.
 - `timeframes` – list of timeframes, each with `tf` (timeframe code) and `keep`

--- a/back_test/backtest_flow.md
+++ b/back_test/backtest_flow.md
@@ -15,7 +15,7 @@
 |
 [แต่ละรอบเวลา:]
 ├─ fetch mt5 ohlcv + sync time
-├─ calculate indicators (SMA, ATR, RSI)
+├─ calculate indicators (SMA, ATR, RSI) ตามการตั้งค่า `indicators`
 ├─ save fetch data as csv
 ├─ build prompt + call GPT API
 ├─ parse response → signal

--- a/config/setting_backtest.example.json
+++ b/config/setting_backtest.example.json
@@ -17,6 +17,7 @@
     "tz_shift": 4,
     "symbol": "XAUUSD",
     "fetch_bars": 30,
+    "indicators": {"atr14": true, "rsi14": true, "sma20": true},
     "time_fetch": "",
     "save_as_path": "data/back_test/fetch",
     "timeframes": [

--- a/config/setting_live_trade.example.json
+++ b/config/setting_live_trade.example.json
@@ -17,6 +17,7 @@
     "tz_shift": 4,
     "symbol": "XAUUSD",
     "fetch_bars": 30,
+    "indicators": {"atr14": true, "rsi14": true, "sma20": true},
     "time_fetch": "",
     "save_as_path": "data/live_trade/fetch",
     "timeframes": [

--- a/docs/flow_overview_th.md
+++ b/docs/flow_overview_th.md
@@ -5,7 +5,7 @@
 รวมถึงไฟล์ `live_trade/live_trade_flow.md` และ `back_test/backtest_flow.md`
 
 1. **Fetch Data** – ดึงข้อมูล OHLC และคำนวณตัวชี้วัด (RSI, SMA, ATR) จาก MT5 หรือ
-   yfinance แล้วบันทึกเป็น CSV และ JSON
+   yfinance แล้วบันทึกเป็น CSV และ JSON โดยสามารถเปิด/ปิดการคำนวณแต่ละค่าได้จากไฟล์คอนฟิก
 2. **Send to GPT** – อ่านไฟล์ JSON และส่งคำสั่ง (prompt) ไปยัง GPT API เพื่อให้สร้างสัญญาณเทรด
 3. **Parse Response** – แปลงข้อความที่ได้จาก GPT เป็น JSON และบันทึกลงไฟล์สัญญาณ
 4. **EA ใน MT5** – อ่านไฟล์สัญญาณทุก ๆ รอบเวลา เพื่อนำไปเปิดคำสั่งซื้อขายจริงหรือตรวจสอบผลในโหมด Backtest

--- a/live_trade/live_trade_flow.md
+++ b/live_trade/live_trade_flow.md
@@ -48,9 +48,10 @@ Logging, monitoring, config เดียวคุมทุกอย่าง
 sync เวลาให้ตรงกับ server/broker เพื่อกันเวลาเพี้ยน
 
 3.2 calculate indicators (SMA, ATR, RSI)
-คำนวณค่า indicators ตาม config
+คำนวณค่า indicators ตาม config และสามารถเปิดหรือปิดการคำนวณแต่ละตัวได้
+ผ่านพารามิเตอร์ `indicators`
 
-สามารถเพิ่ม/ลดได้ทันทีโดยเปลี่ยน config
+สามารถเพิ่ม/ลดได้ทันทีโดยเปลี่ยนค่าคอนฟิก
 
 3.3 save fetch data as csv file
 Save ข้อมูล ohlcv + indicator ไว้ (debug/monitor/backtest)

--- a/src/gpt_trader/fetch/config/fetch_mt5.example.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5.example.json
@@ -2,6 +2,7 @@
   "tz_shift": 4,
   "symbol": "XAUUSD",
   "fetch_bars": 30,
+  "indicators": {"atr14": true, "rsi14": true, "sma20": true},
   "time_fetch": "2024-01-31 12:00:00",
   "timeframes": [
     {"tf": "M5", "keep": 10},

--- a/src/gpt_trader/fetch/config/fetch_mt5.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5.json
@@ -2,6 +2,7 @@
   "tz_shift": 4,
   "symbol": "XAUUSD",
   "fetch_bars": 30,
+  "indicators": {"atr14": true, "rsi14": true, "sma20": true},
   "time_fetch": "",
   "timeframes": [
     {"tf": "M5", "keep": 10},

--- a/src/gpt_trader/fetch/config/fetch_yf.json
+++ b/src/gpt_trader/fetch/config/fetch_yf.json
@@ -2,6 +2,7 @@
   "tz_shift": 7,
   "symbol": "GC=F",
   "fetch_bars": 30,
+  "indicators": {"atr14": true, "rsi14": true, "sma20": true},
   "save_as_path": "data/fetch",
   "timeframes": [
     {"tf": "M5", "keep": 10},

--- a/src/gpt_trader/fetch/fetch_mt5_data.py
+++ b/src/gpt_trader/fetch/fetch_mt5_data.py
@@ -114,6 +114,7 @@ def _fetch_rates(
 def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd.DataFrame:
     """Fetch data for several timeframes and merge into one DataFrame."""
     timeframes_conf = config.get("timeframes", [])
+    indicators_conf = config.get("indicators")
     fetch_bars = int(config.get("fetch_bars", 20))
 
     time_fetch_str = str(config.get("time_fetch", "")).strip()
@@ -135,7 +136,7 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
             raise ValueError(f"Unsupported timeframe: {tf_name}")
         label = _tf_label(tf_name)
         df = _fetch_rates(symbol, tf_const, fetch_bars, tz_shift, end_time)
-        df = compute_indicators(df)
+        df = compute_indicators(df, indicators_conf)
         df = df.tail(keep)
         df["timeframe"] = label
         frames.append(df)

--- a/src/gpt_trader/fetch/fetch_yf_data.py
+++ b/src/gpt_trader/fetch/fetch_yf_data.py
@@ -75,6 +75,7 @@ def _fetch_rates(symbol: str, interval: str, bars: int, tz_shift: int = 0) -> pd
 def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd.DataFrame:
     """Fetch data for several timeframes and merge into one DataFrame."""
     timeframes_conf: List[Dict[str, Any]] = config.get("timeframes", [])
+    indicators_conf = config.get("indicators")
     fetch_bars = int(config.get("fetch_bars", 20))
 
     frames: List[pd.DataFrame] = []
@@ -86,7 +87,7 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
             raise ValueError(f"Unsupported timeframe: {tf_name}")
         label = _tf_label(tf_name)
         df = _fetch_rates(symbol, interval, fetch_bars, tz_shift)
-        df = compute_indicators(df)
+        df = compute_indicators(df, indicators_conf)
         df = df.tail(keep)
         df["timeframe"] = label
         frames.append(df)

--- a/src/gpt_trader/utils/indicators.py
+++ b/src/gpt_trader/utils/indicators.py
@@ -4,28 +4,55 @@ from __future__ import annotations
 import pandas as pd
 
 
-def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
-    """Return a copy of *df* with ATR14, RSI14 and SMA20 columns added."""
+def compute_indicators(
+    df: pd.DataFrame,
+    indicators: dict[str, bool] | None = None,
+) -> pd.DataFrame:
+    """Return a copy of *df* with indicator columns added.
+
+    Parameters
+    ----------
+    df:
+        Input OHLCV DataFrame.
+    indicators:
+        Optional mapping controlling which indicators to compute. Supported keys
+        are ``"atr14"``, ``"rsi14"`` and ``"sma20"``. Missing keys default to
+        ``True``.
+    """
+
+    if indicators is None:
+        indicators = {}
+
     df = df.copy()
 
-    # Average True Range (ATR14)
-    prev_close = df["close"].shift(1)
-    tr = pd.concat(
-        [df["high"] - df["low"], (df["high"] - prev_close).abs(), (df["low"] - prev_close).abs()],
-        axis=1,
-    ).max(axis=1)
-    df["atr14"] = tr.rolling(window=14).mean()
+    if indicators.get("atr14", True):
+        prev_close = df["close"].shift(1)
+        tr = pd.concat(
+            [
+                df["high"] - df["low"],
+                (df["high"] - prev_close).abs(),
+                (df["low"] - prev_close).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        df["atr14"] = tr.rolling(window=14).mean()
+    else:
+        df["atr14"] = pd.NA
 
-    # Relative Strength Index (RSI14)
-    delta = df["close"].diff()
-    gain = delta.clip(lower=0)
-    loss = -delta.clip(upper=0)
-    avg_gain = gain.rolling(window=14).mean()
-    avg_loss = loss.rolling(window=14).mean()
-    rs = avg_gain / avg_loss
-    df["rsi14"] = 100 - 100 / (1 + rs)
+    if indicators.get("rsi14", True):
+        delta = df["close"].diff()
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        avg_gain = gain.rolling(window=14).mean()
+        avg_loss = loss.rolling(window=14).mean()
+        rs = avg_gain / avg_loss
+        df["rsi14"] = 100 - 100 / (1 + rs)
+    else:
+        df["rsi14"] = pd.NA
 
-    # Simple Moving Average (SMA20)
-    df["sma20"] = df["close"].rolling(window=20).mean()
+    if indicators.get("sma20", True):
+        df["sma20"] = df["close"].rolling(window=20).mean()
+    else:
+        df["sma20"] = pd.NA
 
     return df

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from gpt_trader.utils.indicators import compute_indicators
+
+
+def test_disable_single_indicator():
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3],
+            "high": [1, 2, 3],
+            "low": [1, 2, 3],
+            "close": [1, 2, 3],
+        }
+    )
+    out = compute_indicators(df, {"rsi14": False})
+    assert out["rsi14"].isna().all()
+    assert out["atr14"].notna().any()
+    assert not out["sma20"].isna().all()
+
+
+def test_disable_all_indicators():
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3],
+            "high": [1, 2, 3],
+            "low": [1, 2, 3],
+            "close": [1, 2, 3],
+        }
+    )
+    out = compute_indicators(df, {"atr14": False, "rsi14": False, "sma20": False})
+    assert out[["atr14", "rsi14", "sma20"]].isna().all().all()
+


### PR DESCRIPTION
## Summary
- compute indicators optionally based on config
- pass indicator settings to MT5/YF fetchers
- document new `indicators` field
- update workflow docs to mention toggle
- expand example configs
- add unit tests for disabling indicators

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68540c8a99608320ada98bbfa8c98afc