### PR TITLE
Add MT5 signal trigger and latest JSON saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ data/live_trade/save_prompt_api/*
 !data/live_trade/save_prompt_api/.gitkeep
 # Ignore parsed signal files and latest response
 data/live_trade/signals/latest_response.txt
+data/live_trade/signals/latest_response.json
 
 # Ignore backtest data
 data/back_test/*

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ be used to override the search directory. The script also saves a copy of the
 JSON data and the final prompt to `data/live_trade/save_prompt_api` by default. Use
 `--save-dir` or the `save_prompt_dir` config value to change this location.
 
-The parser `src/gpt_trader/parse/parse_gpt_response.py` reads a raw GPT reply and writes the structured result to a JSON file. Default paths are loaded from `src/gpt_trader/parse/config/parse.json` which defines where to store the CSV log, JSON signals and the latest response file. Use `--csv-log`, `--json-dir`, `--latest-response` or `--tz-shift` to override these values. Each run appends a row to the CSV log and saves the parsed data in a uniquely named file like `250616_153045.json` inside the configured directory.
+The parser `src/gpt_trader/parse/parse_gpt_response.py` reads a raw GPT reply and writes the structured result to a JSON file. Default paths are loaded from `src/gpt_trader/parse/config/parse.json` which defines where to store the CSV log, JSON signals and the latest response file. Use `--csv-log`, `--json-dir`, `--latest-response` or `--tz-shift` to override these values. Each run appends a row to the CSV log and saves the parsed data in a uniquely named file like `250616_153045.json` inside the configured directory. A copy of the parsed data is also written to `latest_response.json` alongside the text file for easy access.
 
 ### Creating configuration files
 
@@ -214,6 +214,9 @@ python src/gpt_trader/cli/scheduler_liveTrade.py
 
 The script prints a countdown showing how long remains until the next scheduled
 execution. Press **Ctrl+C** to stop the scheduler.
+
+After each run the file `latest_response.json` is generated and passed to
+`TradeSignalSender` which submits the pending order to MT5 automatically.
 
 ## Backtesting
 

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 
 from main_liveTrade import main as run_main
 from gpt_trader.notify import send_line, send_telegram
+from gpt_trader.cli.lastest_signal_to_mt5 import TradeSignalSender
 
 LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +129,17 @@ def _run_workflow() -> None:
         LOGGER.warning("Failed to update run log: %s", exc)
 
     _notify_summary(notify_cfg, message)
+
+    if results and results.get("parse") == "success":
+        latest_txt = parse_cfg.get(
+            "path_latest_response",
+            "data/live_trade/signals/latest_response.txt",
+        )
+        latest_json = Path(latest_txt).with_suffix(".json")
+        try:
+            TradeSignalSender(str(latest_json))
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Failed to send MT5 signal: %s", exc)
  
 
 def _start_countdown(job) -> None:

--- a/src/gpt_trader/parse/parse_gpt_response.py
+++ b/src/gpt_trader/parse/parse_gpt_response.py
@@ -180,6 +180,14 @@ def main() -> None:
 
     LOGGER.info("Saved signal to %s", output)
 
+    latest_json = Path(args.latest_response).with_suffix(".json")
+    latest_json.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with latest_json.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Failed to update %s: %s", latest_json, exc)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,7 +89,7 @@ def test_notify_called(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_called()
@@ -111,7 +111,7 @@ def test_notify_line_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_not_called()
@@ -132,7 +132,7 @@ def test_notify_telegram_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_not_called()
     tg_fn.assert_called()


### PR DESCRIPTION
## Summary
- save parsed data to `latest_response.json` in addition to the text file
- call `TradeSignalSender` after each scheduled run to push the signal to MT5
- ignore the new JSON file in git
- update README with details about the new file and MT5 automation
- adjust scheduler tests to patch `TradeSignalSender`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6854e9550ef88320af25214a55a2c634