### PR TITLE
Update save_prompt_api file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ unless an absolute path is given.
 
 If you omit the positional `json` argument, `send_to_gpt.py` uses the config
 values described above. The `--data-dir` option defaults to `json_path` and can
-be used to override the search directory. The script also saves a copy of the
-JSON data and the final prompt to `data/live_trade/save_prompt_api` by default. Use
+be used to override the search directory. The script also saves a JSON file
+containing the input data and final prompt to `data/live_trade/save_prompt_api`
+by default. Use
 `--save-dir` or the `save_prompt_dir` config value to change this location.
 
 The parser `src/gpt_trader/parse/parse_gpt_response.py` reads a raw GPT reply and writes the structured result to a JSON file. Default paths are loaded from `src/gpt_trader/parse/config/parse.json` which defines where to store the CSV log, JSON signals and the latest response file. Use `--csv-log`, `--json-dir`, `--latest-response` or `--tz-shift` to override these values. Each run appends a row to the CSV log and saves the parsed data in a uniquely named file like `250616_153045.json` inside the configured directory. A copy of the parsed data is also written to `latest_response.json` alongside the text file for easy access.

--- a/docs/usage_overall_th.md
+++ b/docs/usage_overall_th.md
@@ -47,7 +47,7 @@
 - ข้อมูลที่ดึงมาเก็บใน `data/*/fetch/`
 - ไฟล์สัญญาณ CSV อยู่ใน `data/*/signals/signals_csv/`
 - ไฟล์สัญญาณ JSON อยู่ใน `data/*/signals/signals_json/`
-- สำเนา prompt และ JSON ที่ส่งให้ GPT จะอยู่ใน `data/*/save_prompt_api/`
+- สำเนา prompt และ JSON ที่ส่งให้ GPT จะถูกบันทึกเป็นไฟล์เดียวใน `data/*/save_prompt_api/`
 
 ศึกษา flow รายละเอียดเพิ่มเติมได้ใน [Work_flow.md](../Work_flow.md)
 และไฟล์ในโฟลเดอร์ `live_trade/docs/`

--- a/src/gpt_trader/send/send_to_gpt.py
+++ b/src/gpt_trader/send/send_to_gpt.py
@@ -50,12 +50,14 @@ def _timestamp_code(ts: datetime) -> str:
 def _save_prompt_copy(
     json_path: Path, json_text: str, prompt: str, out_dir: Path
 ) -> None:
-    """Save *json_text* and *prompt* to *out_dir* with a unique name."""
+    """Save *json_text* and *prompt* to *out_dir* as one JSON file."""
     out_dir.mkdir(parents=True, exist_ok=True)
     ts = _timestamp_code(datetime.utcnow())
     base = f"{json_path.stem}_{ts}"
-    (out_dir / f"{base}.json").write_text(json_text, encoding="utf-8")
-    (out_dir / f"{base}_prompt.txt").write_text(prompt, encoding="utf-8")
+    data = {"json": json.loads(json_text), "prompt": prompt}
+    (out_dir / f"{base}.json").write_text(
+        json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 def _build_messages(json_text: str, prompt: str) -> list[dict[str, str]]:

--- a/tests/test_send_to_gpt.py
+++ b/tests/test_send_to_gpt.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from gpt_trader.send.send_to_gpt import _build_messages
+import json
+
+from gpt_trader.send.send_to_gpt import _build_messages, _save_prompt_copy
 
 
 def test_build_messages() -> None:
@@ -11,3 +13,16 @@ def test_build_messages() -> None:
     assert "Prompt" in messages[1]["content"]
     assert "{\"a\":1}" in messages[1]["content"]
     assert "JSON Data:" in messages[1]["content"]
+
+
+def test_save_prompt_copy(tmp_path: Path) -> None:
+    json_path = tmp_path / "foo.json"
+    json_text = "{\"a\": 1}"
+    json_path.write_text(json_text)
+    out_dir = tmp_path / "out"
+    _save_prompt_copy(json_path, json_text, "Prompt", out_dir)
+    files = list(out_dir.glob("*.json"))
+    assert len(files) == 1
+    data = json.loads(files[0].read_text())
+    assert data["prompt"] == "Prompt"
+    assert data["json"] == {"a": 1}


### PR DESCRIPTION
## Summary
- store prompt and data in a single JSON file when sending to GPT
- document new save file behaviour
- clarify Thai usage docs
- test new `_save_prompt_copy` helper

## Testing
- `pytest -q` *(fails: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854fc0692788320bd59a810ff44ed68