### PR TITLE
Add signal prefix and unix timestamp filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ use the same timezone regardless of whether the source is MT5 or Yahoo Finance.
 
 If you do not specify an output path, `fetch_mt5_data.py` saves the CSV
 and an equivalent JSON file in the directory specified by `save_as_path`
-(defaults to `data/live_trade/fetch`). The file name has the form
-`<symbol>_<ddmmyy>_<HH>H_<MM>m.csv` (e.g. `xauusd_250616_16H_30m.csv`).
+(defaults to `data/live_trade/fetch`). The file name now uses a UNIX
+timestamp for uniqueness. It has the form
+`<symbol_signal><unixtime>.csv` (e.g. `xauusd1750424400.csv`). The
+`symbol_signal` value can be set in the configuration and defaults to the
+fetch `symbol` in lower case.
 
 Example `src/gpt_trader/fetch/config/fetch_mt5.json`:
 
@@ -100,6 +103,7 @@ Example `src/gpt_trader/fetch/config/fetch_mt5.json`:
 {
   "tz_shift": 4,
   "symbol": "XAUUSD",
+  "symbol_signal": "xauusd",
   "fetch_bars": 20,
   "time_fetch": "",
   "timeframes": [

--- a/back_test/backtest.json
+++ b/back_test/backtest.json
@@ -12,6 +12,7 @@
   "fetch": {
     "tz_shift": 4,
     "symbol": "XAUUSD",
+    "symbol_signal": "xauusd",
     "fetch_bars": 30,
     "time_fetch": "",
     "save_as_path": "data/back_test/fetch",

--- a/config/setting_backtest.example.json
+++ b/config/setting_backtest.example.json
@@ -16,6 +16,7 @@
   "fetch": {
     "tz_shift": 4,
     "symbol": "XAUUSD",
+    "symbol_signal": "xauusd",
     "fetch_bars": 30,
     "indicators": {"atr14": true, "rsi14": true, "sma20": true},
     "time_fetch": "",

--- a/config/setting_live_trade.example.json
+++ b/config/setting_live_trade.example.json
@@ -16,6 +16,7 @@
   "fetch": {
     "tz_shift": 4,
     "symbol": "XAUUSD",
+    "symbol_signal": "xauusd",
     "fetch_bars": 30,
     "indicators": {"atr14": true, "rsi14": true, "sma20": true},
     "time_fetch": "",

--- a/src/gpt_trader/fetch/config/fetch_mt5.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5.json
@@ -1,6 +1,7 @@
 {
   "tz_shift": 4,
   "symbol": "XAUUSD",
+  "symbol_signal": "xauusd",
   "fetch_bars": 30,
   "indicators": {"atr14": true, "rsi14": true, "sma20": true},
   "time_fetch": "",

--- a/src/gpt_trader/fetch/config/fetch_yf.json
+++ b/src/gpt_trader/fetch/config/fetch_yf.json
@@ -1,6 +1,7 @@
 {
   "tz_shift": 7,
   "symbol": "GC=F",
+  "symbol_signal": "gc_f",
   "fetch_bars": 30,
   "indicators": {"atr14": true, "rsi14": true, "sma20": true},
   "save_as_path": "data/fetch",

--- a/src/gpt_trader/fetch/fetch_mt5_data.py
+++ b/src/gpt_trader/fetch/fetch_mt5_data.py
@@ -70,8 +70,8 @@ def _tf_label(tf: str) -> str:
 
 
 def _timestamp_code(ts: pd.Timestamp) -> str:
-    """Return a string like '250616_16H_30m' for a timestamp."""
-    return ts.strftime("%d%m%y_%HH_%M") + "m"
+    """Return the UNIX timestamp for *ts* as a string."""
+    return str(int(pd.Timestamp(ts).timestamp()))
 
 
 def _fetch_rates(
@@ -202,6 +202,7 @@ def main() -> None:
     args = parser.parse_args(remaining)
 
     symbol = args.symbol or config.get("symbol", "EURUSD")
+    signal_prefix = str(config.get("symbol_signal", symbol)).lower()
 
     if args.time_fetch:
         config["time_fetch"] = args.time_fetch
@@ -226,7 +227,7 @@ def main() -> None:
             if pd.isna(last_ts):
                 raise RuntimeError("No timestamp found in fetched data")
             name = _timestamp_code(last_ts)
-            output = Path(default_save_path) / f"{symbol.lower()}_{name}.csv"
+            output = Path(default_save_path) / f"{signal_prefix}{name}.csv"
         output.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(output, index=False)
         json_out = output.with_suffix(".json")

--- a/src/gpt_trader/fetch/fetch_yf_data.py
+++ b/src/gpt_trader/fetch/fetch_yf_data.py
@@ -40,8 +40,8 @@ def _tf_label(tf: str) -> str:
 
 
 def _timestamp_code(ts: pd.Timestamp) -> str:
-    """Return a string like '250616_16H_30m' for a timestamp."""
-    return ts.strftime("%d%m%y_%HH_%M") + "m"
+    """Return the UNIX timestamp for *ts* as a string."""
+    return str(int(pd.Timestamp(ts).timestamp()))
 
 
 def _fetch_rates(symbol: str, interval: str, bars: int, tz_shift: int = 0) -> pd.DataFrame:
@@ -135,6 +135,7 @@ def main() -> None:
     args = parser.parse_args(remaining)
 
     symbol = args.symbol or config.get("symbol", "EURUSD=X")
+    signal_prefix = str(config.get("symbol_signal", symbol)).lower()
     output = Path(args.output) if args.output else None
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -151,7 +152,7 @@ def main() -> None:
             if pd.isna(last_ts):
                 raise RuntimeError("No timestamp found in fetched data")
             name = _timestamp_code(last_ts)
-            output = Path(default_save_path) / f"{symbol.lower()}_{name}.csv"
+            output = Path(default_save_path) / f"{signal_prefix}{name}.csv"
         output.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(output, index=False)
         json_out = output.with_suffix(".json")


### PR DESCRIPTION
## Summary
- support new `symbol_signal` option for fetch scripts
- save fetched files using unix timestamp
- document new filename format
- update example configs

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685560bead94832084697bc3e93d657c