### PR TITLE
Add weekly window scheduling to liveTrade scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,13 @@ version 3.x is expected but the code attempts to handle version 4.x as well.
 Since
 `main_liveTrade.py` now prepends the repository root to `sys.path`, the
 scheduler can be executed directly from the project root. By default it runs every
-30 minutes, but you can override the interval and the initial delay:
+30 minutes, but you can override the interval, start and stop times:
 
 ```bash
-python src/gpt_trader/cli/scheduler_liveTrade.py --start-in 15 --interval 30
+python src/gpt_trader/cli/scheduler_liveTrade.py \
+  --start-day mon --start-time 08:30 \
+  --stop-day fri --stop-time 23:35 \
+  --interval 30 --start-in 15
 ```
 
 The command above waits 15 minutes before the first run and then repeats every

--- a/docs/usage_linux_th.md
+++ b/docs/usage_linux_th.md
@@ -27,10 +27,13 @@
 
 เรียก `src/gpt_trader/cli/scheduler_liveTrade.py` เพื่อตั้งเวลารัน `main_liveTrade.py` ซ้ำ ๆ
 
-ตัวอย่างเริ่มต้นใน 15 นาที แล้วทำงานทุก 60 นาที:
+ตัวอย่างกำหนดวันและเวลาเริ่ม/หยุด พร้อมระยะเวลาห่างกัน 30 นาที:
 
 ```bash
-python src/gpt_trader/cli/scheduler_liveTrade.py --start-in 15 --interval 60
+python src/gpt_trader/cli/scheduler_liveTrade.py \
+  --start-day mon --start-time 08:30 \
+  --stop-day fri --stop-time 23:35 \
+  --interval 30 --start-in 15
 ```
 
 กด **Ctrl+C** เพื่อหยุดการทำงานของ scheduler

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,39 @@
+from datetime import datetime, time
+
+from gpt_trader.cli.scheduler_liveTrade import _within_window
+
+
+def test_within_window_basic() -> None:
+    assert _within_window(
+        datetime(2024, 6, 10, 10, 0),
+        0,
+        time(8, 30),
+        4,
+        time(23, 35),
+    )
+    assert not _within_window(
+        datetime(2024, 6, 15, 1, 0),
+        0,
+        time(8, 30),
+        4,
+        time(23, 35),
+    )
+
+
+def test_within_window_cross_week() -> None:
+    start_day = 4  # Friday
+    stop_day = 0  # Monday
+    assert _within_window(
+        datetime(2024, 6, 8, 1, 0),
+        start_day,
+        time(23, 0),
+        stop_day,
+        time(5, 0),
+    )
+    assert not _within_window(
+        datetime(2024, 6, 10, 6, 0),
+        start_day,
+        time(23, 0),
+        stop_day,
+        time(5, 0),
+    )


### PR DESCRIPTION
## Summary
- let scheduler_liveTrade run only within a start/stop day+time window
- show the window in startup logs
- document new CLI arguments in README and docs
- test _within_window helper

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6c308e4832099949e7adeeeac54