### PR TITLE
Fix timezone comparison in scheduler

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -113,6 +113,8 @@ def _next_window_run(
     """Return the first run time >= *next_run* within the active window."""
 
     start_of_window = datetime.combine(next_run.date(), start_time)
+    if next_run.tzinfo is not None and start_of_window.tzinfo is None:
+        start_of_window = start_of_window.replace(tzinfo=next_run.tzinfo)
     start_of_window += timedelta(days=(start_day - start_of_window.weekday()) % 7)
 
     if start_of_window < next_run:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 
 from gpt_trader.cli.scheduler_liveTrade import _within_window, _next_window_run
 
@@ -63,3 +63,16 @@ def test_next_run_aligns_to_start_time() -> None:
         time(23, 35),
     )
     assert next_run == datetime(2024, 6, 10, 8, 30)
+
+
+def test_next_run_timezone_aware() -> None:
+    start = datetime(2024, 6, 9, 17, 21, tzinfo=timezone.utc)
+    next_run = _next_window_run(
+        start,
+        30,
+        0,
+        time(8, 30),
+        4,
+        time(23, 35),
+    )
+    assert next_run == datetime(2024, 6, 10, 8, 30, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- fix comparison between naive and timezone-aware datetimes
- cover timezone-aware datetimes in scheduler tests

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858133ee44c8320b4431edd42577f2a