### PR TITLE
Add session column to fetchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ timestamp for uniqueness. It has the form
 `symbol_signal` value can be set in the configuration and defaults to the
 fetch `symbol` in lower case.
 
+Each row in the output also includes a `session` field that labels the
+bar as belonging to the **asia**, **london** or **newyork** trading
+session based on the shifted timestamp.
+
 Example `src/gpt_trader/fetch/config/fetch_mt5.json`:
 
 ```json

--- a/config/setting_backtest.example.json
+++ b/config/setting_backtest.example.json
@@ -25,7 +25,8 @@
       {"tf": "M5", "keep": 10},
       {"tf": "M15", "keep": 6},
       {"tf": "H1", "keep": 4}
-    ]
+    ],
+    "note": "Fetched CSV/JSON includes a 'session' column (asia/london/newyork)"
   },
   "send": {
     "openai_api_key": "YOUR_API_KEY",

--- a/config/setting_live_trade.example.json
+++ b/config/setting_live_trade.example.json
@@ -25,7 +25,8 @@
       {"tf": "M5", "keep": 10},
       {"tf": "M15", "keep": 6},
       {"tf": "H1", "keep": 4}
-    ]
+    ],
+    "note": "Fetched CSV/JSON includes a 'session' column (asia/london/newyork)"
   },
   "send": {
     "openai_api_key": "YOUR_API_KEY",

--- a/src/gpt_trader/fetch/config/fetch_mt5.example.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5.example.json
@@ -8,5 +8,6 @@
     {"tf": "M5", "keep": 10},
     {"tf": "M15", "keep": 6},
     {"tf": "H1", "keep": 4}
-  ]
+  ],
+  "note": "Fetched CSV/JSON includes a 'session' column (asia/london/newyork)"
 }

--- a/src/gpt_trader/fetch/config/fetch_mt5.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5.json
@@ -9,5 +9,6 @@
     {"tf": "M5", "keep": 10},
     {"tf": "M15", "keep": 6},
     {"tf": "H1", "keep": 4}
-  ]
+  ],
+  "note": "Fetched CSV/JSON includes a 'session' column (asia/london/newyork)"
 }

--- a/src/gpt_trader/fetch/config/fetch_yf.json
+++ b/src/gpt_trader/fetch/config/fetch_yf.json
@@ -9,5 +9,6 @@
     {"tf": "M5", "keep": 10},
     {"tf": "M15", "keep": 6},
     {"tf": "H1", "keep": 4}
-  ]
+  ],
+  "note": "Fetched CSV/JSON includes a 'session' column (asia/london/newyork)"
 }

--- a/src/gpt_trader/fetch/fetch_mt5_data.py
+++ b/src/gpt_trader/fetch/fetch_mt5_data.py
@@ -74,6 +74,16 @@ def _timestamp_code(ts: pd.Timestamp) -> str:
     return str(int(pd.Timestamp(ts).timestamp()))
 
 
+def get_session(ts: pd.Timestamp) -> str:
+    """Return the trading session name for *ts*."""
+    hour = pd.Timestamp(ts).hour
+    if 0 <= hour < 8:
+        return "asia"
+    if 8 <= hour < 16:
+        return "london"
+    return "newyork"
+
+
 def _fetch_rates(
     symbol: str,
     timeframe: int,
@@ -146,7 +156,9 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
         raise ValueError(
             "Timestamp format must be YYYY-MM-DD HH:MM:SS and the chosen date may not be available"
         )
-    # Reorder columns
+
+    combined["session"] = combined["timestamp"].apply(get_session)
+
     cols = [
         "timestamp",
         "open",
@@ -158,6 +170,7 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
         "rsi14",
         "sma20",
         "timeframe",
+        "session",
     ]
     combined = combined[cols]
     return combined

--- a/src/gpt_trader/fetch/fetch_yf_data.py
+++ b/src/gpt_trader/fetch/fetch_yf_data.py
@@ -44,6 +44,16 @@ def _timestamp_code(ts: pd.Timestamp) -> str:
     return str(int(pd.Timestamp(ts).timestamp()))
 
 
+def get_session(ts: pd.Timestamp) -> str:
+    """Return the trading session name for *ts*."""
+    hour = pd.Timestamp(ts).hour
+    if 0 <= hour < 8:
+        return "asia"
+    if 8 <= hour < 16:
+        return "london"
+    return "newyork"
+
+
 def _fetch_rates(symbol: str, interval: str, bars: int, tz_shift: int = 0) -> pd.DataFrame:
     """Fetch OHLC data from yfinance."""
     LOGGER.info("Fetching %s bars for %s interval", bars, interval)
@@ -93,6 +103,8 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
         frames.append(df)
 
     combined = pd.concat(frames, ignore_index=True)
+    combined["session"] = combined["timestamp"].apply(get_session)
+
     cols = [
         "timestamp",
         "open",
@@ -104,6 +116,7 @@ def fetch_multi_tf(symbol: str, config: Dict[str, Any], tz_shift: int = 0) -> pd
         "rsi14",
         "sma20",
         "timeframe",
+        "session",
     ]
     return combined[cols]
 

--- a/tests/test_fetch_mt5_data.py
+++ b/tests/test_fetch_mt5_data.py
@@ -49,6 +49,8 @@ def test_fetch_multi_tf_tz_shift_and_latest_bar() -> None:
     expected_times = pd.date_range("2024-01-01", periods=5, freq="min") + pd.Timedelta(hours=2)
     assert list(df["timestamp"]) == list(expected_times)
     assert df["timestamp"].iloc[-1] == expected_times[-1]
+    expected_sessions = [fetch_mt5_data.get_session(ts) for ts in expected_times]
+    assert list(df["session"]) == expected_sessions
 
 
 def test_fetch_multi_tf_with_time_fetch() -> None:
@@ -99,6 +101,8 @@ def test_fetch_multi_tf_with_time_fetch() -> None:
     assert list(df["timestamp"]) == list(sample_times)
     assert called["start"].strftime("%Y-%m-%d %H:%M:%S") == "2024-01-01 00:00:00"
     assert called["end"].strftime("%Y-%m-%d %H:%M:%S") == "2024-01-01 00:04:00"
+    expected_sessions = [fetch_mt5_data.get_session(ts) for ts in sample_times]
+    assert list(df["session"]) == expected_sessions
 
 
 def test_fetch_multi_tf_invalid_time_fetch() -> None:
@@ -186,6 +190,7 @@ def test_main_writes_to_save_as_path(tmp_path) -> None:
             "rsi14": [0],
             "sma20": [0],
             "timeframe": ["1m"],
+            "session": ["asia"],
         }
     )
 

--- a/tests/test_fetch_yf_data.py
+++ b/tests/test_fetch_yf_data.py
@@ -7,7 +7,7 @@ import importlib
 import pandas as pd
 import pytest
 
-from gpt_trader.fetch.fetch_yf_data import fetch_multi_tf
+from gpt_trader.fetch.fetch_yf_data import fetch_multi_tf, get_session
 
 
 def _fake_download(
@@ -33,6 +33,10 @@ def test_fetch_multi_tf_returns_dataframe() -> None:
         df = fetch_multi_tf("TEST", config, tz_shift=0)
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
+    expected_sessions = [
+        get_session(ts) for ts in pd.date_range("2024-01-01", periods=5, freq="min")
+    ]
+    assert list(df["session"]) == expected_sessions
 
 
 def test_tz_shift_applied() -> None:
@@ -45,6 +49,8 @@ def test_tz_shift_applied() -> None:
         hours=3
     )
     assert list(df["timestamp"]) == list(expected)
+    expected_sessions = [get_session(ts) for ts in expected]
+    assert list(df["session"]) == expected_sessions
 
 
 def test_main_error_on_empty_df(tmp_path, caplog) -> None:


### PR DESCRIPTION
## Summary
- label each row with trading session
- expose get_session helper in data fetchers
- include session column in CSV/JSON output
- adjust sample configs and docs
- update tests for new column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68590f52e6a88320ae2f3f1858095acf