### PR TITLE
Add regime type to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ with **MetaEditor**. The indicator calculates RSI‑14, SMA‑20 and ATR‑14 fo
 current chart timeframe. If the `DisplaySignals` parameter is enabled it reads
 the latest JSON file from the `data/live_trade/signals/signals_json/` directory and shows the parsed values
 on the chart. Each JSON signal must include the fields `signal_id`, `entry`, `sl`,
-`tp`, `pending_order_type` and `confidence`.
+`tp`, `pending_order_type`, `confidence` and `regime_type`.
 
 ### Compile & Attach
 

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -155,6 +155,8 @@ def _format_summary_message(detail: str, status: str, signal: dict | None) -> st
                 f"⭐ confidence:{signal.get('confidence')}",
             ]
         )
+        if signal.get("regime_type") is not None:
+            parts.append(f"📊 regime_type:{signal['regime_type']}")
         if signal.get("lot") is not None:
             parts.append(f"💵 lot:{signal['lot']}")
         if signal.get("rr") is not None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,11 +89,12 @@ def test_notify_called(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_called()
     assert "signal_id:id" in line_fn.call_args[0][0]
+    assert "regime_type:trend" in line_fn.call_args[0][0]
 
 
 def test_notify_line_only(tmp_path):
@@ -111,7 +112,7 @@ def test_notify_line_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_not_called()
@@ -132,7 +133,7 @@ def test_notify_telegram_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_not_called()
     tg_fn.assert_called()
@@ -165,7 +166,7 @@ def test_order_before_notification(tmp_path):
     ), patch.object(
         sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}
     ), patch.object(
-        sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55}
+        sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}
     ), patch.object(
         sched, "send_line", side_effect=record_notify
     ) as line_fn, patch.object(
@@ -179,3 +180,4 @@ def test_order_before_notification(tmp_path):
     msg = line_fn.call_args[0][0]
     assert "lot:" in msg
     assert "rr:" in msg
+    assert "regime_type:trend" in msg


### PR DESCRIPTION
## Summary
- show `regime_type` in summary notifications
- document new field in README
- expect regime type in scheduler workflow tests

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_68591197ac888320a55b4a566902911b