### PR TITLE
Add short_reason to notification message

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ with **MetaEditor**. The indicator calculates RSI‑14, SMA‑20 and ATR‑14 fo
 current chart timeframe. If the `DisplaySignals` parameter is enabled it reads
 the latest JSON file from the `data/live_trade/signals/signals_json/` directory and shows the parsed values
 on the chart. Each JSON signal must include the fields `signal_id`, `entry`, `sl`,
-`tp`, `pending_order_type`, `confidence` and `regime_type`.
+`tp`, `pending_order_type`, `confidence`, `regime_type` and `short_reason`.
 
 ### Compile & Attach
 

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -165,6 +165,8 @@ def _format_summary_message(detail: str, status: str, signal: dict | None) -> st
             except Exception:
                 rr_fmt = str(signal['rr'])
             parts.append(f"📈 rr:{rr_fmt}")
+        if signal.get("short_reason") is not None:
+            parts.append(f"📝 short_reason:{signal['short_reason']}")
     return "\n".join(parts)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,12 +89,13 @@ def test_notify_called(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend", "short_reason": "r"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_called()
     assert "signal_id:id" in line_fn.call_args[0][0]
     assert "regime_type:trend" in line_fn.call_args[0][0]
+    assert "short_reason:" in line_fn.call_args[0][0]
 
 
 def test_notify_line_only(tmp_path):
@@ -112,7 +113,7 @@ def test_notify_line_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend", "short_reason": "r"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_not_called()
@@ -133,7 +134,7 @@ def test_notify_telegram_only(tmp_path):
 
     with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
         sched, "LOG_FILE", log_path
-    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
+    ), patch.object(sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}), patch.object(sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend", "short_reason": "r"}), patch.object(sched, "send_line") as line_fn, patch.object(sched, "send_telegram") as tg_fn, patch.object(sched, "TradeSignalSender") as sender_cls:
         sched._run_workflow()
     line_fn.assert_not_called()
     tg_fn.assert_called()
@@ -166,7 +167,7 @@ def test_order_before_notification(tmp_path):
     ), patch.object(
         sched, "run_main", return_value={"fetch": "success", "send": "success", "parse": "success"}
     ), patch.object(
-        sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend"}
+        sched, "_load_latest_signal", return_value={"signal_id": "id", "entry": 1, "sl": 2, "tp": 3, "pending_order_type": "buy_limit", "confidence": 55, "regime_type": "trend", "short_reason": "r"}
     ), patch.object(
         sched, "send_line", side_effect=record_notify
     ) as line_fn, patch.object(
@@ -181,3 +182,4 @@ def test_order_before_notification(tmp_path):
     assert "lot:" in msg
     assert "rr:" in msg
     assert "regime_type:trend" in msg
+    assert "short_reason:" in msg


### PR DESCRIPTION
## Summary
- show `short_reason` in notification summary
- document new JSON field in README
- expect short_reason in scheduler tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685915ad28848320afd58923998eea3f