### PR TITLE
Fix skip signal processing before symbol parse

### DIFF
--- a/src/gpt_trader/cli/latest_signal_to_mt5.py
+++ b/src/gpt_trader/cli/latest_signal_to_mt5.py
@@ -21,7 +21,15 @@ class TradeSignalSender:
     ):
         self.signal_path = signal_path
         self.signal = self.load_signal()
-        self.symbol_base = self.extract_symbol_base()
+        self.pending_order_type = (
+            str(self.signal.get("pending_order_type", ""))
+            .lower()
+            .replace(" ", "_")
+        )
+        if self.pending_order_type != "skip":
+            self.symbol_base = self.extract_symbol_base()
+        else:
+            self.symbol_base = None
         self.symbol_map = {k.upper(): v for k, v in (symbol_map or SYMBOL_MAP).items()}
         self.symbol = None
         self.entry = None
@@ -32,7 +40,6 @@ class TradeSignalSender:
         self.confidence = None
         self.max_drawdown = None
         self.risk_per_trade = risk_per_trade
-        self.pending_order_type = None
         self.order_type = None
         self.balance = None
 
@@ -109,7 +116,6 @@ class TradeSignalSender:
                 self.entry = market_price + min_diff if "buy" in self.pending_order_type else market_price - min_diff
 
     def process(self):
-        self.pending_order_type = str(self.signal.get("pending_order_type", "")).lower().replace(" ", "_")
         if self.pending_order_type == "skip":
             reason = self.signal.get("short_reason", "")
             print(f"⏭️ Skipping signal {self.signal['signal_id']} {reason}")

--- a/tests/test_skip_signal.py
+++ b/tests/test_skip_signal.py
@@ -25,3 +25,24 @@ def test_skip_signal_no_mt5_calls(tmp_path: Path) -> None:
         mod.TradeSignalSender(str(sig))
 
     assert calls == []
+
+
+def test_skip_signal_numeric_id(tmp_path: Path) -> None:
+    data = {
+        "signal_id": 123,
+        "pending_order_type": "skip",
+    }
+    sig = tmp_path / "sig.json"
+    sig.write_text(json.dumps(data))
+
+    mt5 = ModuleType("MetaTrader5")
+    calls: list[str] = []
+    mt5.initialize = lambda: calls.append("init") or True
+    mt5.shutdown = lambda: calls.append("shutdown")
+
+    with importlib.import_module("unittest.mock").patch.dict(sys.modules, {"MetaTrader5": mt5}):
+        mod = importlib.import_module("gpt_trader.cli.latest_signal_to_mt5")
+        importlib.reload(mod)
+        mod.TradeSignalSender(str(sig))
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- avoid parsing symbol when pending order type is skip
- update skip signal tests for numeric ID handling

## Testing
- `pytest -q` *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859279d095c8320b230b437a45758cd