### PR TITLE
Add next run timestamp in scheduler output

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -302,8 +302,9 @@ def _start_countdown(
                     break
                 hours, rem = divmod(int(remaining.total_seconds()), 3600)
                 minutes, seconds = divmod(rem, 60)
+                ts = next_run.strftime("%H:%M:%S")
                 print(
-                    f"Next run in {hours:02d}:{minutes:02d}:{seconds:02d}",
+                    f"Next run at {ts} ({hours:02d}:{minutes:02d}:{seconds:02d})",
                     end="\r",
                     flush=True,
                 )


### PR DESCRIPTION
## Summary
- display the exact time of the next scheduled run in `scheduler_liveTrade.py`

## Testing
- `pre-commit` *(fails: ModuleNotFoundError: No module named 'pre_commit')*


------
https://chatgpt.com/codex/tasks/task_e_6859435d91fc8320be008e17637973c0