### PR TITLE
Adjust default start time to 08:20

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ schedule. The script uses APScheduler to call `main_liveTrade.py` repeatedly
 `main_liveTrade.py` prepends the repository root to `sys.path` so the scheduler
 can be executed directly from the project root. The workflow is executed once
 immediately and then the next run is scheduled for the configured start window
-(by default Monday at 08:30). After that it repeats every 30 minutes. You can
+(by default Monday at 08:20). After that it repeats every 30 minutes. You can
 override the interval, start and stop times:
 
 ```bash
 python src/gpt_trader/cli/scheduler_liveTrade.py \
-  --start-day mon --start-time 08:30 \
+  --start-day mon --start-time 08:20 \
   --stop-day fri --stop-time 23:35 \
   --interval 30 --start-in 15
 ```

--- a/docs/usage_linux_th.md
+++ b/docs/usage_linux_th.md
@@ -28,13 +28,13 @@
 เรียก `src/gpt_trader/cli/scheduler_liveTrade.py` เพื่อตั้งเวลารัน
 `main_liveTrade.py` ซ้ำ ๆ โดยสคริปต์จะรัน workflow หนึ่งครั้งทันทีที่
 เริ่มต้น แล้วจึงนัดรอบถัดไปตามช่วงเวลาที่กำหนด (ค่าเริ่มต้นคือทุกวันจันทร์
-เวลา 08:30 แล้ววนทุก 30 นาทีจนถึงเวลาหยุดที่ตั้งไว้)
+เวลา 08:20 แล้ววนทุก 30 นาทีจนถึงเวลาหยุดที่ตั้งไว้)
 
 ตัวอย่างกำหนดวันและเวลาเริ่ม/หยุด พร้อมระยะเวลาห่างกัน 30 นาที:
 
 ```bash
 python src/gpt_trader/cli/scheduler_liveTrade.py \
-  --start-day mon --start-time 08:30 \
+  --start-day mon --start-time 08:20 \
   --stop-day fri --stop-time 23:35 \
   --interval 30 --start-in 15
 ```

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -340,7 +340,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--start-time",
-        default="08:30",
+        default="08:20",
         help="Time of day to start (HH:MM)",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- update docs to show scheduler default start time 08:20
- change scheduler default `--start-time` argument from 08:30 to 08:20

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685947fbc3248320a1caa528195c8a2a