### PR TITLE
Handle Timestamp types in json_io

### DIFF
--- a/src/gpt_trader/utils/json_io.py
+++ b/src/gpt_trader/utils/json_io.py
@@ -2,14 +2,26 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 
 
 def write_json_no_nulls(df: pd.DataFrame, path: Path) -> None:
-    """Write *df* to *path* as JSON omitting null values."""
-    records = []
+    """Write *df* to *path* as JSON omitting null values.
+
+    ``pandas.Timestamp`` values are converted to ISO formatted strings so that
+    ``json.dumps`` receives only serializable objects.
+    """
+
+    records: list[dict[str, Any]] = []
     for record in df.to_dict(orient="records"):
-        clean = {k: v for k, v in record.items() if not pd.isna(v)}
+        clean: dict[str, Any] = {}
+        for k, v in record.items():
+            if pd.isna(v):
+                continue
+            if isinstance(v, pd.Timestamp):
+                v = v.isoformat()
+            clean[k] = v
         records.append(clean)
     path.write_text(json.dumps(records, ensure_ascii=False), encoding="utf-8")

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -12,3 +12,12 @@ def test_write_json_no_nulls(tmp_path: Path) -> None:
     write_json_no_nulls(df, out)
     data = json.loads(out.read_text())
     assert data == [{"a": 1, "b": 2}, {"b": 3}]
+
+
+def test_write_json_timestamp_conversion(tmp_path: Path) -> None:
+    df = pd.DataFrame({"dt": [pd.Timestamp("2024-01-01 12:34:56")]})
+    out = tmp_path / "ts.json"
+    write_json_no_nulls(df, out)
+    data = json.loads(out.read_text())
+    assert data == [{"dt": "2024-01-01T12:34:56"}]
+    assert isinstance(data[0]["dt"], str)


### PR DESCRIPTION
## Summary
- update `write_json_no_nulls` to convert `pandas.Timestamp` values to ISO strings
- test timestamp serialization in `json_io`

## Testing
- `bash scripts/install_deps.sh` *(fails: Could not install dependencies)*
- `pytest tests/test_json_io.py -q` *(fails: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a57789f4c8320a6492bb4b29cdd4b