### PR TITLE
Fix TP handling

### DIFF
--- a/src/gpt_trader/cli/latest_signal_to_mt5.py
+++ b/src/gpt_trader/cli/latest_signal_to_mt5.py
@@ -69,11 +69,8 @@ class TradeSignalSender:
         return None
 
     def calculate_risk_reward(self):
+        """Calculate the risk/reward ratio without altering ``tp``."""
         self.rr = 1 + (100 - self.confidence) / 50
-        if "buy" in self.pending_order_type:
-            self.tp = self.entry + (self.entry - self.sl) * self.rr
-        else:
-            self.tp = self.entry - (self.sl - self.entry) * self.rr
 
     def calculate_lot(self, balance, tick_value, tick_size, volume_min,
                       volume_max, volume_step):
@@ -145,6 +142,10 @@ class TradeSignalSender:
         self.balance = account.balance
         self.entry = float(self.signal["entry"])
         self.sl = float(self.signal["sl"])
+        if "tp" not in self.signal:
+            mt5.shutdown()
+            raise ValueError("❌ 'tp' missing from signal")
+        self.tp = float(self.signal["tp"])
         self.confidence = int(self.signal.get("confidence", 70))
         self.max_drawdown = float(self.signal.get("max_drawdown", 15))
         if self.max_risk_per_trade is not None:
@@ -159,7 +160,7 @@ class TradeSignalSender:
 
         self.prepare_order_type()
 
-        # Use the entry price from the GPT response without modification
+        # Use entry and TP values from the GPT response without modification
 
         self.calculate_risk_reward()
         self.lot = self.calculate_lot(

--- a/tests/test_risk_management.py
+++ b/tests/test_risk_management.py
@@ -153,3 +153,22 @@ def test_max_risk_caps_value(tmp_path) -> None:
         sender = mod.TradeSignalSender(str(path), max_risk_per_trade=2)
         assert sender.risk_per_trade == 2
 
+
+def test_tp_value_preserved(tmp_path) -> None:
+    """TP from the JSON signal should not be modified."""
+    mt5 = _make_mt5_stub()
+    with importlib.import_module("unittest.mock").patch.dict(sys.modules, {"MetaTrader5": mt5}):
+        mod = importlib.import_module("gpt_trader.cli.latest_signal_to_mt5")
+        importlib.reload(mod)
+        data = {
+            "signal_id": "xauusd-test",
+            "entry": 2000,
+            "sl": 1995,
+            "tp": 1990,
+            "pending_order_type": "sell_limit",
+        }
+        path = tmp_path / "sig.json"
+        path.write_text(importlib.import_module("json").dumps(data))
+        sender = mod.TradeSignalSender(str(path))
+        assert sender.tp == 1990
+


### PR DESCRIPTION
## Summary
- keep TP price from JSON signal
- update risk management tests

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a6c3ca7808320be23a43270b6c625