### PR TITLE
Enhance notification output

### DIFF
--- a/live_trade/docs/usage_th.md
+++ b/live_trade/docs/usage_th.md
@@ -57,3 +57,5 @@ python src/gpt_trader/cli/liveTrade_scheduler.py
 หากกำหนด `notify` และเปิด `line.enabled` หรือ `telegram.enabled` ระบบจะส่งสรุปผลการรัน
 ผ่าน LINE หรือ Telegram ตามค่า token และ chat_id ในแต่ละส่วน
 นอกจากนี้ไฟล์ `logs/run.log` จะบันทึกข้อความแจ้งเตือนทุกครั้งที่มีการส่ง LINE หรือ Telegram
+ข้อความที่ส่งจะแสดงรายละเอียดสัญญาณ รวมถึงค่า `risk_per_trade` ที่ใช้เปิดออเดอร์
+เพื่อให้ผู้อ่านเห็นเปอร์เซ็นต์ความเสี่ยงของคำสั่งแต่ละครั้งอย่างชัดเจน

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -144,29 +144,39 @@ def _format_summary_message(detail: str, status: str, signal: dict | None) -> st
         }
         order_type = signal.get("pending_order_type")
         emoji = type_map.get(str(order_type).lower(), "")
-        parts.extend(
-            [
-                f"📌 signal_id:{signal.get('signal_id')}",
-                f"💰 entry:{signal.get('entry')}",
-                f"🛑 sl:{signal.get('sl')}",
-                f"🎯 tp:{signal.get('tp')}",
-                f"{emoji} pending_order_type:{order_type}",
-                f"⭐ confidence:{signal.get('confidence')}",
-            ]
-        )
-        if signal.get("regime_type") is not None:
-            parts.append(f"📊 regime_type:{signal['regime_type']}")
+
+        basic = [
+            f"📌 signal_id:{signal.get('signal_id')}",
+            f"💰 entry:{signal.get('entry')}",
+            f"🛑 sl:{signal.get('sl')}",
+            f"🎯 tp:{signal.get('tp')}",
+            f"{emoji} pending_order_type:{order_type}",
+            f"⭐ confidence:{signal.get('confidence')}",
+        ]
+        parts.append("\n".join(basic))
+
+        extra: list[str] = []
+        if signal.get("risk_per_trade") is not None:
+            extra.append(f"⚖ risk_per_trade:{signal['risk_per_trade']}%")
         if signal.get("lot") is not None:
-            parts.append(f"💵 lot:{signal['lot']}")
+            extra.append(f"💵 lot:{signal['lot']}")
         if signal.get("rr") is not None:
             try:
                 rr_fmt = f"{float(signal['rr']):.2f}"
             except Exception:
                 rr_fmt = str(signal['rr'])
-            parts.append(f"📈 rr:{rr_fmt}")
+            extra.append(f"📈 rr:{rr_fmt}")
+        if signal.get("regime_type") is not None:
+            extra.append(f"📊 regime_type:{signal['regime_type']}")
+        if extra:
+            parts.append("")
+            parts.append("\n".join(extra))
+
         if signal.get("short_reason") is not None:
+            parts.append("")
             parts.append(f"📝 short_reason:{signal['short_reason']}")
         if signal.get("order_status") is not None:
+            parts.append("")
             parts.append(f"🚩 order:{signal['order_status']}")
     return "\n".join(parts)
 
@@ -246,6 +256,7 @@ def _run_workflow() -> None:
                 )
                 signal["lot"] = sender.lot
                 signal["rr"] = sender.rr
+                signal["risk_per_trade"] = sender.risk_per_trade
                 order_status = sender.order_result
                 signal["order_status"] = order_status
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -112,6 +112,7 @@ def test_notify_called(tmp_path):
         mock_sender = MagicMock()
         mock_sender.lot = 0.1
         mock_sender.rr = 1.5
+        mock_sender.risk_per_trade = 1.0
         mock_sender.order_result = "success"
         sender_cls.return_value = mock_sender
         sched._run_workflow()
@@ -119,6 +120,7 @@ def test_notify_called(tmp_path):
     tg_fn.assert_called()
     assert "signal_id:id" in line_fn.call_args[0][0]
     assert "regime_type:trend" in line_fn.call_args[0][0]
+    assert "risk_per_trade:" in line_fn.call_args[0][0]
     assert "short_reason:" in line_fn.call_args[0][0]
     assert "order:success" in line_fn.call_args[0][0]
 
@@ -142,11 +144,13 @@ def test_notify_line_only(tmp_path):
         mock_sender = MagicMock()
         mock_sender.lot = 0.1
         mock_sender.rr = 1.5
+        mock_sender.risk_per_trade = 1.0
         mock_sender.order_result = "success"
         sender_cls.return_value = mock_sender
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_not_called()
+    assert "risk_per_trade:" in line_fn.call_args[0][0]
     assert "order:success" in line_fn.call_args[0][0]
 
 
@@ -169,11 +173,13 @@ def test_notify_telegram_only(tmp_path):
         mock_sender = MagicMock()
         mock_sender.lot = 0.1
         mock_sender.rr = 1.5
+        mock_sender.risk_per_trade = 1.0
         mock_sender.order_result = "success"
         sender_cls.return_value = mock_sender
         sched._run_workflow()
     line_fn.assert_not_called()
     tg_fn.assert_called()
+    assert "risk_per_trade:" in tg_fn.call_args[0][0]
     assert "order:success" in tg_fn.call_args[0][0]
 
 
@@ -197,6 +203,7 @@ def test_order_before_notification(tmp_path):
         mock = MagicMock()
         mock.lot = 0.1
         mock.rr = 1.5
+        mock.risk_per_trade = 1.0
         mock.order_result = "success"
         return mock
 
@@ -219,6 +226,7 @@ def test_order_before_notification(tmp_path):
     msg = line_fn.call_args[0][0]
     assert "lot:" in msg
     assert "rr:" in msg
+    assert "risk_per_trade:" in msg
     assert "regime_type:trend" in msg
     assert "short_reason:" in msg
     assert "order:success" in msg


### PR DESCRIPTION
## Summary
- display risk percent for each order in the message
- format notification text into sections with blank lines
- mention risk percentage info in Thai usage docs
- adjust tests for new notification output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a891b2e0c8320b7a50efb4260c263