### PR TITLE
Format risk_per_trade in summary message

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -157,7 +157,11 @@ def _format_summary_message(detail: str, status: str, signal: dict | None) -> st
 
         extra: list[str] = []
         if signal.get("risk_per_trade") is not None:
-            extra.append(f"⚖ risk_per_trade:{signal['risk_per_trade']}%")
+            try:
+                rp_fmt = f"{float(signal['risk_per_trade']):.3f}"
+            except Exception:  # noqa: BLE001
+                rp_fmt = str(signal['risk_per_trade'])
+            extra.append(f"⚖ risk_per_trade:{rp_fmt}%")
         if signal.get("lot") is not None:
             extra.append(f"💵 lot:{signal['lot']}")
         if signal.get("rr") is not None:


### PR DESCRIPTION
## Summary
- ensure risk_per_trade is rounded to three decimals when creating notification messages

## Testing
- `pytest -q` *(fails: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a8b838f4083208cbbf65e5a115320