### PR TITLE
Add basic Express API

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -1,0 +1,59 @@
+import express from 'express';
+import {
+  insertSignal,
+  insertOrder,
+  insertTrade,
+  insertEvent,
+} from './services/db.js';
+
+const app = express();
+app.use(express.json());
+
+app.post('/signal', async (req, res) => {
+  try {
+    const result = await insertSignal(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save signal' });
+  }
+});
+
+app.post('/order', async (req, res) => {
+  try {
+    const result = await insertOrder(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save order' });
+  }
+});
+
+app.post('/trade', async (req, res) => {
+  try {
+    const result = await insertTrade(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save trade' });
+  }
+});
+
+app.post('/event', async (req, res) => {
+  try {
+    const result = await insertEvent(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save event' });
+  }
+});
+
+export default app;
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`API server listening on port ${port}`);
+  });
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-trading-api",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@supabase/supabase-js": "^2.39.7"
+  }
+}

--- a/api/services/db.js
+++ b/api/services/db.js
@@ -1,0 +1,46 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);
+
+export async function insertSignal(data) {
+  const { data: result, error } = await supabase
+    .from('signals')
+    .insert(data)
+    .select()
+    .single();
+  if (error) throw error;
+  return result;
+}
+
+export async function insertOrder(data) {
+  const { data: result, error } = await supabase
+    .from('pending_orders')
+    .insert(data)
+    .select()
+    .single();
+  if (error) throw error;
+  return result;
+}
+
+export async function insertTrade(data) {
+  const { data: result, error } = await supabase
+    .from('trades')
+    .insert(data)
+    .select()
+    .single();
+  if (error) throw error;
+  return result;
+}
+
+export async function insertEvent(data) {
+  const { data: result, error } = await supabase
+    .from('trade_events')
+    .insert(data)
+    .select()
+    .single();
+  if (error) throw error;
+  return result;
+}


### PR DESCRIPTION
## Summary
- add initial Express server and Supabase client
- setup routes for trading endpoints

## Testing
- `./scripts/install_deps.sh` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685b93d5db2c832089bfbe0ae67d94b7