### PR TITLE
Add Supabase schema and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,20 @@ Run the tests with:
 pytest
 ```
 
+## Supabase schema
+
+The SQL schema for storing signals, orders and trades lives in
+`supabase/schema.sql`. Create a new Supabase project and apply the file using
+the Supabase CLI:
+
+```bash
+supabase db remote set <database-url>
+supabase db push supabase/schema.sql
+```
+
+You can also run the commands in the Supabase web dashboard. After the tables
+are created, set `SUPABASE_URL` and `SUPABASE_KEY` so the API can connect.
+
 ## Troubleshooting
 
 - **`MetaTrader5.initialize()` fails** – ensure the desktop terminal is installed
@@ -337,6 +351,7 @@ pytest
 - [สรุปรายการไฟล์ในโครงการ](docs/files_overview_th.md)
 - [ภาพรวม flow การทำงาน](docs/flow_overview_th.md)
 - [การติดตั้งบน Linux/Wine และใช้งาน scheduler](docs/usage_linux_th.md)
+- [Supabase setup](docs/supabase_setup.md)
 
 
 ## License

--- a/docs/supabase_setup.md
+++ b/docs/supabase_setup.md
@@ -1,0 +1,18 @@
+# Setting up Supabase
+
+This project stores trading records in a Supabase PostgreSQL database. The SQL schema can be found in `supabase/schema.sql`.
+
+## Applying the schema
+
+1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and login.
+2. Create a new project from the Supabase dashboard.
+3. Run the SQL file in the project database:
+
+   ```bash
+   supabase db remote set <database-url>
+   supabase db push supabase/schema.sql
+   ```
+
+   Alternatively, you can paste the contents of `schema.sql` into the SQL editor on the Supabase dashboard and execute it.
+
+After the tables are created, update your environment variables `SUPABASE_URL` and `SUPABASE_KEY` so the application can connect to your project.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,54 @@
+-- Supabase schema for automated trading system
+-- Run this script inside a Supabase SQL editor or through psql
+
+CREATE TABLE signals (
+    signal_id TEXT PRIMARY KEY,
+    symbol TEXT,
+    entry REAL,
+    sl REAL,
+    tp REAL,
+    type TEXT,
+    confidence INTEGER,
+    regime_type TEXT,
+    created_at TIMESTAMPTZ
+);
+
+CREATE TABLE pending_orders (
+    id UUID PRIMARY KEY,
+    signal_id TEXT REFERENCES signals(signal_id),
+    status TEXT,
+    sent_time TIMESTAMPTZ,
+    filled_time TIMESTAMPTZ,
+    cancel_reason TEXT
+);
+
+CREATE TABLE trades (
+    id UUID PRIMARY KEY,
+    signal_id TEXT REFERENCES signals(signal_id),
+    pending_order_id UUID REFERENCES pending_orders(id),
+    open_time TIMESTAMPTZ,
+    close_time TIMESTAMPTZ,
+    entry REAL,
+    exit REAL,
+    profit REAL,
+    lot_size REAL,
+    status TEXT,
+    strategy TEXT
+);
+
+CREATE TABLE trade_events (
+    id UUID PRIMARY KEY,
+    trade_id UUID REFERENCES trades(id),
+    event_type TEXT,
+    event_time TIMESTAMPTZ,
+    details TEXT
+);
+
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY,
+    signal_id TEXT REFERENCES signals(signal_id),
+    channel TEXT,
+    message TEXT,
+    status TEXT,
+    sent_time TIMESTAMPTZ
+);


### PR DESCRIPTION
## Summary
- add SQL schema for Supabase tables
- document how to apply the schema
- mention schema setup in README

## Testing
- `pytest -q` *(fails: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b966fc0c4832089193478b6954d86