### PR TITLE
Improve Thai docs

### DIFF
--- a/docs/backend_usage_th.md
+++ b/docs/backend_usage_th.md
@@ -1,30 +1,38 @@
 # คู่มือใช้งาน Backend API
 
-เอกสารนี้อธิบายขั้นตอนการติดตั้งและใช้งานเซิร์ฟเวอร์ API ในโฟลเดอร์ `backend/api` ซึ่งพัฒนาโดยใช้ Node.js และ Express.js โดยข้อมูลทั้งหมดจะถูกบันทึกลงฐานข้อมูล Supabase ตาม schema ใน `backend/supabase/schema.sql`.
+เอกสารนี้อธิบายการตั้งค่าและใช้งานเซิร์ฟเวอร์ที่อยู่ในโฟลเดอร์ `backend/api` ซึ่งเขียนด้วย Node.js และ Express.js ผู้ที่ไม่เคยใช้ Node.js มาก่อนก็สามารถทำตามขั้นตอนต่อไปนี้ได้
 
-## 1. ติดตั้งแพ็กเกจ Node.js
+## 1. เตรียมเครื่องมือพื้นฐาน
 
-```bash
-cd backend/api
-npm install
-```
-
-คำสั่งนี้จะติดตั้ง `express` และ `@supabase/supabase-js` ตามที่ระบุไว้ใน `package.json`.
+1. ติดตั้ง Node.js เวอร์ชัน LTS จาก <https://nodejs.org>
+   เมื่อติดตั้งเสร็จให้ตรวจสอบด้วย
+   ```bash
+   node -v
+   npm -v
+   ```
+   หากแสดงหมายเลขเวอร์ชันแสดงว่าใช้งานได้แล้ว
+2. ติดตั้งไลบรารีที่ใช้ในโปรเจกต์
+   ```bash
+   cd backend/api
+   npm install
+   ```
+   คำสั่งนี้จะดาวน์โหลดแพ็กเกจใน `package.json` เช่น `express` และ `@supabase/supabase-js`
 
 ## 2. กำหนดตัวแปรสภาพแวดล้อม
 
-เซิร์ฟเวอร์จำเป็นต้องรู้ URL และคีย์ของโปรเจกต์ Supabase ก่อนเริ่มทำงาน กำหนดค่าดังนี้
+เซิร์ฟเวอร์ต้องรู้ข้อมูลเชื่อมต่อกับ Supabase และพอร์ตที่เปิดบริการ ตัวอย่างแบบง่ายใช้คำสั่ง
 
 ```bash
-export SUPABASE_URL="https://<project-ref>.supabase.co"
-export SUPABASE_KEY="<service-role-key>"
-# เลือกพอร์ตได้ (ค่าเริ่มต้น 3000)
-export PORT=3000
+export SUPABASE_URL='https://<project-ref>.supabase.co'
+export SUPABASE_KEY='<service-role-key>'
+export PORT=3000   # เปลี่ยนได้ตามต้องการ
 ```
+
+ค่าตัวแปรดูได้จากหน้า **Settings → API** ในโปรเจกต์ Supabase หากไม่กำหนด `PORT` จะใช้ค่าเริ่มต้น 3000
 
 ## 3. รันเซิร์ฟเวอร์
 
-เมื่อกำหนดตัวแปรครบแล้ว สามารถเริ่มเซิร์ฟเวอร์ได้ด้วย
+เมื่อกำหนดค่าครบแล้วให้เริ่มเซิร์ฟเวอร์ด้วย
 
 ```bash
 npm start
@@ -32,28 +40,27 @@ npm start
 node app.js
 ```
 
-หากไม่มีการระบุค่า `PORT` เซิร์ฟเวอร์จะเปิดที่พอร์ต `3000` โดยจะแสดงข้อความ `API server listening on port 3000` ในคอนโซล
+หากทุกอย่างถูกต้อง คอนโซลจะแสดงข้อความ `API server listening on port 3000`
 
-## 4. การใช้งาน API
+## 4. Endpoint ที่ให้บริการ
 
-เซิร์ฟเวอร์มี endpoint สำหรับบันทึกข้อมูล 4 ชนิด ซึ่งจะเขียนลงตารางที่สอดคล้องกันใน Supabase
+เซิร์ฟเวอร์มี 4 เส้นทางสำหรับรับข้อมูลและบันทึกลงฐานข้อมูล
 
-- `POST /signal` – เพิ่มข้อมูลสัญญาณเข้า table `signals`
-- `POST /order` – เพิ่มคำสั่งที่รอเข้าไม้ใน table `pending_orders`
-- `POST /trade` – บันทึกผลการเทรดใน table `trades`
-- `POST /event` – บันทึกเหตุการณ์ต่าง ๆ ใน table `trade_events`
+- `POST /signal` – บันทึกสัญญาณเทรดลงตาราง `signals`
+- `POST /order` – บันทึกรายการคำสั่งรอเข้าตลาดใน `pending_orders`
+- `POST /trade` – บันทึกผลการเทรดจริงใน `trades`
+- `POST /event` – บันทึกเหตุการณ์ต่าง ๆ ใน `trade_events`
 
-ตัวอย่างเรียกใช้งานด้วย `curl`
+ควรส่งข้อมูลเป็น JSON ให้ครบตาม schema ไม่เช่นนั้นจะได้รับข้อความ error กลับมา
+
+ตัวอย่างเรียก `POST /signal` ด้วย `curl`
 
 ```bash
 curl -X POST http://localhost:3000/signal \
-     -H "Content-Type: application/json" \
+     -H 'Content-Type: application/json' \
      -d '{"signal_id":"demo_01","symbol":"XAUUSD","entry":2320.5,"sl":2315,"tp":2335,"type":"buy_limit","confidence":80}'
 ```
 
-ควรตรวจสอบว่าแต่ละคีย์ตรงกับชนิดข้อมูลใน `backend/supabase/schema.sql` ก่อนส่งเข้าระบบ
+## 5. การเตรียมฐานข้อมูล
 
-## 5. เตรียมฐานข้อมูล
-
-หากยังไม่ได้สร้างตาราง สามารถดูวิธีตั้งค่า Supabase ได้ที่ [docs/supabase_setup.md](supabase_setup.md) จากนั้นจึงกำหนดค่า `SUPABASE_URL` และ `SUPABASE_KEY` ตามโปรเจกต์ของคุณ
-
+หากยังไม่ได้สร้างตารางใน Supabase ให้ดูวิธีใน [supabase_setup.md](supabase_setup.md) ก่อน เมื่อตารางพร้อมแล้วเซิร์ฟเวอร์ก็จะบันทึกข้อมูลได้ทันที

--- a/docs/supabase_setup.md
+++ b/docs/supabase_setup.md
@@ -1,18 +1,45 @@
-# Setting up Supabase
+# การตั้งค่า Supabase
 
-This project stores trading records in a Supabase PostgreSQL database. The SQL schema can be found in `backend/supabase/schema.sql`.
+ระบบนี้บันทึกข้อมูลการเทรดไว้ในฐานข้อมูล PostgreSQL บน Supabase ไฟล์สำหรับสร้างตารางอยู่ที่ `backend/supabase/schema.sql`
 
-## Applying the schema
+## 1. เตรียมบัญชีและโปรเจกต์
 
-1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and login.
-2. Create a new project from the Supabase dashboard.
-3. Run the SQL file in the project database:
+1. สมัครสมาชิกที่ <https://supabase.com> และเข้าสู่ระบบ
+2. กด **New Project** ตั้งชื่อโปรเจกต์และรหัสผ่านฐานข้อมูล รอสักครู่จนระบบสร้างเสร็จ
 
+## 2. ติดตั้งและตั้งค่า Supabase CLI
+
+1. ติดตั้ง Node.js หากยังไม่มี จากนั้นรัน
    ```bash
-   supabase db remote set <database-url>
+   npm install -g supabase
+   ```
+2. เข้าสู่ระบบผ่าน CLI
+   ```bash
+   supabase login
+   ```
+   นำ access token จากหน้าเว็บมาวางตามที่ระบบถาม
+
+## 3. นำ schema เข้าสู่ฐานข้อมูล
+
+1. คัดลอกค่า **Connection string** จากหน้า **Settings → Database** ของโปรเจกต์ เช่น
+   `postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres`
+2. ตั้งค่าการเชื่อมต่อให้ CLI
+   ```bash
+   supabase db remote set 'postgresql://...'
+   ```
+3. จาก root ของโปรเจกต์ รันคำสั่ง
+   ```bash
    supabase db push backend/supabase/schema.sql
    ```
+   CLI จะสร้างตารางตามไฟล์ `schema.sql` ให้อัตโนมัติ หากไม่ใช้ CLI สามารถเปิด SQL editor บนเว็บแล้ววางไฟล์ไปรันได้เช่นกัน
 
-   Alternatively, you can paste the contents of `schema.sql` into the SQL editor on the Supabase dashboard and execute it.
+## 4. กำหนดตัวแปรสภาพแวดล้อม
 
-After the tables are created, update your environment variables `SUPABASE_URL` and `SUPABASE_KEY` so the application can connect to your project.
+หลังจากสร้างตารางแล้ว ให้กำหนดตัวแปรดังนี้เพื่อให้โค้ดเชื่อมต่อได้
+
+```bash
+export SUPABASE_URL='https://<project-ref>.supabase.co'
+export SUPABASE_KEY='<service-role-key>'
+```
+
+ดูค่าทั้งสองได้จากหน้า **Settings → API** ในโปรเจกต์ของคุณ


### PR DESCRIPTION
## Summary
- update Supabase setup guide in Thai
- rewrite backend API usage guide with more detailed steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685d42374378832084f8c64032a22013