### PR TITLE
Add TypeScript Neon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,17 @@ supabase db push backend/supabase/schema.sql
 You can also run the commands in the Supabase web dashboard. After the tables
 are created, set `SUPABASE_URL` and `SUPABASE_KEY` so the API can connect.
 
+The repository also provides a TypeScript version of the API under
+`backend/neon-ts`. It exposes the same `/signal`, `/order`, `/trade` and
+`/event` endpoints but connects to a Neon database via `DATABASE_URL`.
+
+```bash
+cd backend/neon-ts
+npm install
+npm run build
+npm start
+```
+
 ## Troubleshooting
 
 - **`MetaTrader5.initialize()` fails** – ensure the desktop terminal is installed

--- a/backend/neon-ts/.env.example
+++ b/backend/neon-ts/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgres://user:password@host/db"

--- a/backend/neon-ts/package.json
+++ b/backend/neon-ts/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "neon-ts-api",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.1",
+    "dotenv": "^16.5.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.6"
+  }
+}

--- a/backend/neon-ts/src/db.ts
+++ b/backend/neon-ts/src/db.ts
@@ -1,0 +1,18 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function insert(table: string, data: Record<string, unknown>) {
+  const keys = Object.keys(data);
+  const values = keys.map((k) => (data as any)[k]);
+  const placeholders = keys.map((_, i) => `$${i + 1}`).join(',');
+  const query = `INSERT INTO ${table} (${keys.join(',')}) VALUES (${placeholders}) RETURNING *`;
+  const result = await pool.query(query, values);
+  return result.rows[0];
+}
+
+export const insertSignal = (data: Record<string, unknown>) => insert('signals', data);
+export const insertOrder = (data: Record<string, unknown>) => insert('pending_orders', data);
+export const insertTrade = (data: Record<string, unknown>) => insert('trades', data);
+export const insertEvent = (data: Record<string, unknown>) => insert('trade_events', data);

--- a/backend/neon-ts/src/server.ts
+++ b/backend/neon-ts/src/server.ts
@@ -1,0 +1,54 @@
+import express from 'express';
+import { insertSignal, insertOrder, insertTrade, insertEvent } from './db';
+
+const app = express();
+app.use(express.json());
+
+app.post('/signal', async (req, res) => {
+  try {
+    const result = await insertSignal(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save signal' });
+  }
+});
+
+app.post('/order', async (req, res) => {
+  try {
+    const result = await insertOrder(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save order' });
+  }
+});
+
+app.post('/trade', async (req, res) => {
+  try {
+    const result = await insertTrade(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save trade' });
+  }
+});
+
+app.post('/event', async (req, res) => {
+  try {
+    const result = await insertEvent(req.body);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save event' });
+  }
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`API server listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/backend/neon-ts/tsconfig.json
+++ b/backend/neon-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/docs/backend_usage_th.md
+++ b/docs/backend_usage_th.md
@@ -1,6 +1,11 @@
 # คู่มือใช้งาน Backend API
 
-เอกสารนี้อธิบายการตั้งค่าและใช้งานเซิร์ฟเวอร์ที่อยู่ในโฟลเดอร์ `backend/api` ซึ่งเขียนด้วย Node.js และ Express.js ผู้ที่ไม่เคยใช้ Node.js มาก่อนก็สามารถทำตามขั้นตอนต่อไปนี้ได้
+เอกสารนี้อธิบายการตั้งค่าและใช้งานเซิร์ฟเวอร์ Backend ซึ่งมีให้เลือกสองแบบ
+
+1. เวอร์ชันดั้งเดิมในโฟลเดอร์ `backend/api` เขียนด้วย JavaScript เชื่อมต่อ Supabase
+2. เวอร์ชัน TypeScript ในโฟลเดอร์ `backend/neon-ts` ใช้ฐานข้อมูล Neon ผ่านตัวแปร `DATABASE_URL`
+
+ผู้ที่ไม่เคยใช้ Node.js มาก่อนก็สามารถทำตามขั้นตอนต่อไปนี้ได้
 
 ## 1. เตรียมเครื่องมือพื้นฐาน
 
@@ -12,24 +17,31 @@
    ```
    หากแสดงหมายเลขเวอร์ชันแสดงว่าใช้งานได้แล้ว
 2. ติดตั้งไลบรารีที่ใช้ในโปรเจกต์
-   ```bash
-   cd backend/api
-   npm install
-   ```
-   คำสั่งนี้จะดาวน์โหลดแพ็กเกจใน `package.json` เช่น `express` และ `@supabase/supabase-js`
+  ```bash
+  cd backend/api
+  npm install
+  ```
+  คำสั่งนี้จะดาวน์โหลดแพ็กเกจใน `package.json` เช่น `express` และ `@supabase/supabase-js`
+
+  หากใช้เวอร์ชัน TypeScript ให้ติดตั้งภายใต้ `backend/neon-ts`
+
+  ```bash
+  cd backend/neon-ts
+  npm install
+  ```
 
 ## 2. กำหนดตัวแปรสภาพแวดล้อม
 
-เซิร์ฟเวอร์ต้องรู้ข้อมูลเชื่อมต่อกับ Supabase และพอร์ตที่เปิดบริการ ตัวอย่างแบบง่ายใช้คำสั่ง
+เซิร์ฟเวอร์ต้องรู้ข้อมูลเชื่อมต่อกับฐานข้อมูลและพอร์ตที่เปิดบริการ ตัวอย่างแบบง่ายใช้คำสั่ง
 
 ```bash
-export SUPABASE_URL='https://<project-ref>.supabase.co'
-export SUPABASE_KEY='<service-role-key>'
-export PORT=3000   # เปลี่ยนได้ตามต้องการ
+export SUPABASE_URL="https://<project-ref>.supabase.co"
+export SUPABASE_KEY="<service-role-key>"
+export DATABASE_URL="postgres://<user>:<pass>@<host>/<db>"
+export PORT=3000  # เปลี่ยนได้ตามต้องการ
 ```
 
-ค่าตัวแปรดูได้จากหน้า **Settings → API** ในโปรเจกต์ Supabase หากไม่กำหนด `PORT` จะใช้ค่าเริ่มต้น 3000
-
+ค่าตัวแปรดูได้จากหน้า **Settings → API** ในโปรเจกต์ของคุณ หากไม่กำหนด `PORT` จะใช้ค่าเริ่มต้น 3000
 ## 3. รันเซิร์ฟเวอร์
 
 เมื่อกำหนดค่าครบแล้วให้เริ่มเซิร์ฟเวอร์ด้วย

--- a/docs/files_overview_th.md
+++ b/docs/files_overview_th.md
@@ -14,7 +14,7 @@
 | `data/` | ที่เก็บผลลัพธ์ต่าง ๆ เช่น CSV/JSON |
 | `scripts/` | สคริปต์ช่วยเหลือ เช่น ติดตั้งไลบรารี |
 | `tests/` | ชุดทดสอบอัตโนมัติ |
-| `backend/` | โฟลเดอร์รวม API server และไฟล์ schema ของ Supabase |
+| `backend/` | โฟลเดอร์รวม API server และไฟล์ schema ของ Supabase รวมถึงเวอร์ชัน TypeScript (`neon-ts`) |
 
 ## โมดูล `src/gpt_trader`
 


### PR DESCRIPTION
## Summary
- add new Express server in `backend/neon-ts` using TypeScript and pg
- document how to run the Neon version of the API
- mention the new folder in Thai docs

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e94ef9020832089923b7ec9e98765