### PR TITLE
Update backend docs and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,15 @@ Run the tests with:
 pytest
 ```
 
-## Supabase schema
+## Backend directories
+
+The `backend` folder now contains multiple implementations:
+
+- `api/` – JavaScript server that connects to Supabase
+- `neon-ts/` – TypeScript server deployed with Neon using `DATABASE_URL`
+- `supabase/` – `schema.sql` for creating tables
+
+### Supabase schema
 
 The SQL schema for storing signals, orders and trades lives in
 `backend/supabase/schema.sql`. Create a new Supabase project and apply the file using

--- a/docs/backend_usage_th.md
+++ b/docs/backend_usage_th.md
@@ -1,9 +1,10 @@
 # คู่มือใช้งาน Backend API
 
-เอกสารนี้อธิบายการตั้งค่าและใช้งานเซิร์ฟเวอร์ Backend ซึ่งมีให้เลือกสองแบบ
+เอกสารนี้อธิบายการตั้งค่าและใช้งานเซิร์ฟเวอร์ Backend ซึ่งแบ่งโครงสร้างดังนี้
 
-1. เวอร์ชันดั้งเดิมในโฟลเดอร์ `backend/api` เขียนด้วย JavaScript เชื่อมต่อ Supabase
-2. เวอร์ชัน TypeScript ในโฟลเดอร์ `backend/neon-ts` ใช้ฐานข้อมูล Neon ผ่านตัวแปร `DATABASE_URL`
+1. **`backend/api`** – เวอร์ชันดั้งเดิมเขียนด้วย JavaScript เชื่อมต่อ Supabase
+2. **`backend/neon-ts`** – เวอร์ชัน TypeScript เชื่อมฐานข้อมูล Neon ผ่านตัวแปร `DATABASE_URL`
+3. **`backend/supabase`** – ไฟล์ `schema.sql` สำหรับสร้างตาราง PostgreSQL
 
 ผู้ที่ไม่เคยใช้ Node.js มาก่อนก็สามารถทำตามขั้นตอนต่อไปนี้ได้
 
@@ -23,25 +24,30 @@
   ```
   คำสั่งนี้จะดาวน์โหลดแพ็กเกจใน `package.json` เช่น `express` และ `@supabase/supabase-js`
 
-  หากใช้เวอร์ชัน TypeScript ให้ติดตั้งภายใต้ `backend/neon-ts`
+  หากใช้เวอร์ชัน TypeScript ให้ติดตั้งและคอมไพล์ภายใต้ `backend/neon-ts`
 
   ```bash
   cd backend/neon-ts
   npm install
+  npm run build
   ```
 
 ## 2. กำหนดตัวแปรสภาพแวดล้อม
 
-เซิร์ฟเวอร์ต้องรู้ข้อมูลเชื่อมต่อกับฐานข้อมูลและพอร์ตที่เปิดบริการ ตัวอย่างแบบง่ายใช้คำสั่ง
+เซิร์ฟเวอร์ต้องรู้ข้อมูลเชื่อมต่อกับฐานข้อมูลและพอร์ตที่เปิดบริการ ตัวอย่างการตั้งค่ามีดังนี้
 
 ```bash
+# สำหรับเวอร์ชัน JavaScript
 export SUPABASE_URL="https://<project-ref>.supabase.co"
 export SUPABASE_KEY="<service-role-key>"
+
+# สำหรับเวอร์ชัน TypeScript (Neon)
 export DATABASE_URL="postgres://<user>:<pass>@<host>/<db>"
+
 export PORT=3000  # เปลี่ยนได้ตามต้องการ
 ```
 
-ค่าตัวแปรดูได้จากหน้า **Settings → API** ในโปรเจกต์ของคุณ หากไม่กำหนด `PORT` จะใช้ค่าเริ่มต้น 3000
+ค่าตัวแปรดูได้จากหน้า **Settings → API** ในโปรเจกต์ หรือจากแดชบอร์ดของ Neon หากไม่กำหนด `PORT` จะใช้ค่าเริ่มต้น 3000
 ## 3. รันเซิร์ฟเวอร์
 
 เมื่อกำหนดค่าครบแล้วให้เริ่มเซิร์ฟเวอร์ด้วย
@@ -76,3 +82,15 @@ curl -X POST http://localhost:3000/signal \
 ## 5. การเตรียมฐานข้อมูล
 
 หากยังไม่ได้สร้างตารางใน Supabase ให้ดูวิธีใน [supabase_setup.md](supabase_setup.md) ก่อน เมื่อตารางพร้อมแล้วเซิร์ฟเวอร์ก็จะบันทึกข้อมูลได้ทันที
+
+## 6. Deploy โปรเจกต์ขึ้น Vercel และ Neon
+
+สำหรับเวอร์ชัน TypeScript สามารถนำไป deploy บน Vercel ได้ง่าย ๆ ขั้นตอนโดยสรุปคือ
+
+1. สร้างบัญชี Vercel และเชื่อมต่อรีโปนี้
+2. ตั้งค่า Environment Variable ชื่อ `DATABASE_URL` ให้ชี้ไปยังฐานข้อมูล Neon ของคุณ
+3. กด **Deploy** หรือใช้คำสั่ง
+   ```bash
+   vercel --prod
+   ```
+เมื่อ deploy เสร็จ API จะพร้อมใช้งานผ่าน URL ของ Vercel

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,24 +1,24 @@
-# Visualizing Supabase data in Grafana and Retool
+# Visualizing Neon data in Grafana and Retool
 
-This guide shows how to connect your Supabase PostgreSQL database to either Grafana or Retool in order to build dashboards for your trading records.
+This guide shows how to connect your Neon PostgreSQL database to either Grafana or Retool in order to build dashboards for your trading records.
 
 ## Connecting Grafana
 
 1. Open Grafana and go to **Configuration → Data sources**.
 2. Click **Add data source** and choose **PostgreSQL**.
-3. Fill in the connection details from your Supabase project:
-   - **Host**: `db.<project-ref>.supabase.co`
-   - **Database**: `postgres`
-   - **User**: `postgres`
-   - **Password**: your database password
+3. Fill in the connection details from your Neon project:
+   - **Host**: `<neon-host>.neon.tech`
+   - **Database**: name of your database
+   - **User**: your Neon user
+   - **Password**: your Neon password
    - **SSL mode**: `require`
-4. Save the data source. Grafana can now query your Supabase tables.
+4. Save the data source. Grafana can now query your Neon tables.
 
 ## Connecting Retool
 
 1. In Retool, navigate to **Resources** and create a new **PostgreSQL** resource.
-2. Enter the same connection parameters as above. You can copy the full connection string from the Supabase dashboard under **Settings → Database**.
-3. Test the connection and save. Retool queries will now run against Supabase.
+2. Enter the same connection parameters as above. You can copy the full connection string from the Neon dashboard.
+3. Test the connection and save. Retool queries will now run against Neon.
 
 ## Example queries
 

--- a/docs/files_overview_th.md
+++ b/docs/files_overview_th.md
@@ -14,7 +14,7 @@
 | `data/` | ที่เก็บผลลัพธ์ต่าง ๆ เช่น CSV/JSON |
 | `scripts/` | สคริปต์ช่วยเหลือ เช่น ติดตั้งไลบรารี |
 | `tests/` | ชุดทดสอบอัตโนมัติ |
-| `backend/` | โฟลเดอร์รวม API server และไฟล์ schema ของ Supabase รวมถึงเวอร์ชัน TypeScript (`neon-ts`) |
+| `backend/` | รวมซอร์สโค้ด API หลายเวอร์ชัน<br>├─ `api/` JavaScript เชื่อมต่อ Supabase<br>├─ `neon-ts/` TypeScript ใช้ฐานข้อมูล Neon<br>└─ `supabase/` ไฟล์ `schema.sql` |
 
 ## โมดูล `src/gpt_trader`
 

--- a/docs/supabase_setup.md
+++ b/docs/supabase_setup.md
@@ -1,6 +1,8 @@
 # การตั้งค่า Supabase
 
 ระบบนี้บันทึกข้อมูลการเทรดไว้ในฐานข้อมูล PostgreSQL บน Supabase ไฟล์สำหรับสร้างตารางอยู่ที่ `backend/supabase/schema.sql`
+โฟลเดอร์ `backend` แยกซอร์สออกเป็น
+`api/` (JavaScript ใช้ Supabase) และ `neon-ts/` (TypeScript เชื่อม Neon) เพื่อให้เลือกใช้งานได้ตามต้องการ
 
 ## 1. เตรียมบัญชีและโปรเจกต์
 


### PR DESCRIPTION
## Summary
- explain backend folder structure and Neon deployment
- describe installing deps and DATABASE_URL usage
- update Grafana/Retool examples for Neon

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d9595d48320a0e4ca06c305a008