### PR TITLE
Update Neon TS backend

### DIFF
--- a/backend/neon-ts/package.json
+++ b/backend/neon-ts/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "pg": "^8.11.1",
+    "@neondatabase/serverless": "^0.8.0",
     "dotenv": "^16.5.0"
   },
   "devDependencies": {

--- a/backend/neon-ts/src/db.ts
+++ b/backend/neon-ts/src/db.ts
@@ -1,15 +1,14 @@
 import 'dotenv/config';
-import { Pool } from 'pg';
-
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+import { neon } from '@neondatabase/serverless';
+const sql = neon(process.env.DATABASE_URL as string);
 
 async function insert(table: string, data: Record<string, unknown>) {
   const keys = Object.keys(data);
   const values = keys.map((k) => (data as any)[k]);
   const placeholders = keys.map((_, i) => `$${i + 1}`).join(',');
   const query = `INSERT INTO ${table} (${keys.join(',')}) VALUES (${placeholders}) RETURNING *`;
-  const result = await pool.query(query, values);
-  return result.rows[0];
+  const { rows } = await sql(query, values);
+  return rows[0];
 }
 
 export const insertSignal = (data: Record<string, unknown>) => insert('signals', data);

--- a/docs/backend_usage_th.md
+++ b/docs/backend_usage_th.md
@@ -4,7 +4,7 @@
 
 1. **`backend/api`** – เวอร์ชันดั้งเดิมเขียนด้วย JavaScript ใช้โมดูล `pg` เชื่อมฐานข้อมูลผ่านตัวแปร `DATABASE_URL`
    โค้ดหลักอยู่ที่ `app.js` และ `services/db.js`
-2. **`backend/neon-ts`** – เวอร์ชัน TypeScript เชื่อมฐานข้อมูล Neon ผ่านตัวแปร `DATABASE_URL`
+2. **`backend/neon-ts`** – เวอร์ชัน TypeScript เชื่อมฐานข้อมูล Neon ด้วยไลบรารี `@neondatabase/serverless` ผ่านตัวแปร `DATABASE_URL`
 
 ผู้ที่ไม่เคยใช้ Node.js มาก่อนก็สามารถทำตามขั้นตอนต่อไปนี้ได้
 
@@ -22,9 +22,9 @@
   cd backend/api
   npm install
   ```
-  คำสั่งนี้จะดาวน์โหลดแพ็กเกจใน `package.json` เช่น `express` และ `pg`
+  คำสั่งนี้จะดาวน์โหลดแพ็กเกจใน `package.json` เช่น `express` และ `@neondatabase/serverless`
 
-  หากใช้เวอร์ชัน TypeScript ให้ติดตั้งและคอมไพล์ภายใต้ `backend/neon-ts`
+  หากใช้เวอร์ชัน TypeScript ให้ติดตั้งไลบรารีและคอมไพล์ภายใต้ `backend/neon-ts`
 
   ```bash
   cd backend/neon-ts


### PR DESCRIPTION
## Summary
- use `@neondatabase/serverless` instead of `pg`
- update TypeScript DB module to create a Neon client via `neon()`
- document the new dependency in the Thai backend guide

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5deaeb88320bbbfb9f9c096b6b8