### PR TITLE
Implement database logging for notifications

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -23,6 +23,7 @@ if str(ROOT) not in sys.path:
 from gpt_trader.cli.live_trade_workflow import main as run_main
 from gpt_trader.notify import send_line, send_telegram
 from gpt_trader.cli.latest_signal_to_mt5 import TradeSignalSender
+from gpt_trader.utils import post_event
 
 LOGGER = logging.getLogger(__name__)
 
@@ -287,6 +288,17 @@ def _run_workflow() -> None:
         LOGGER.warning("Failed to update run log: %s", exc)
 
     _notify_summary(notify_cfg, message)
+
+    neon_cfg = cfg.get("neon", {})
+    if neon_cfg.get("api_url"):
+        try:
+            post_event(
+                neon_cfg.get("api_url", ""),
+                neon_cfg.get("auth_token", ""),
+                {"message": message},
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Failed to save notification to DB: %s", exc)
 
 
 def _make_workflow_runner(

--- a/src/gpt_trader/utils/__init__.py
+++ b/src/gpt_trader/utils/__init__.py
@@ -1,4 +1,4 @@
 from .json_io import write_json_no_nulls
-from .api_client import post_signal
+from .api_client import post_signal, post_event
 
-__all__ = ["write_json_no_nulls", "post_signal"]
+__all__ = ["write_json_no_nulls", "post_signal", "post_event"]

--- a/src/gpt_trader/utils/api_client.py
+++ b/src/gpt_trader/utils/api_client.py
@@ -22,4 +22,17 @@ def post_signal(base_url: str, token: str, data: dict[str, Any]) -> None:
         LOGGER.error("Signal POST failed: %s", exc)
         raise
 
-__all__ = ["post_signal"]
+
+def post_event(base_url: str, token: str, data: dict[str, Any]) -> None:
+    """POST *data* to ``/event`` on *base_url* using Bearer *token*."""
+    url = base_url.rstrip("/") + "/event"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        resp = requests.post(url, json=data, headers=headers, timeout=10)
+        resp.raise_for_status()
+        LOGGER.info("Posted event to %s", url)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error("Event POST failed: %s", exc)
+        raise
+
+__all__ = ["post_signal", "post_event"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -372,3 +372,51 @@ def test_order_before_notification(tmp_path):
     assert "regime_type:trend" in msg
     assert "short_reason:" in msg
     assert "order:success" in msg
+
+
+def test_notify_saved_to_db(tmp_path):
+    cfg = {
+        "notify": {"line": {"enabled": True, "token": "t"}},
+        "neon": {"api_url": "http://db"},
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+    log_path = tmp_path / "run.log"
+
+    import gpt_trader.cli.scheduler_liveTrade as sched
+
+    with patch.object(sched, "DEFAULT_CFG", cfg_path), patch.object(
+        sched, "LOG_FILE", log_path
+    ), patch.object(
+        sched,
+        "run_main",
+        return_value={"fetch": "success", "send": "success", "parse": "success"},
+    ), patch.object(
+        sched,
+        "_load_latest_signal",
+        return_value={
+            "signal_id": "id",
+            "entry": 1,
+            "sl": 2,
+            "tp": 3,
+            "pending_order_type": "buy_limit",
+            "confidence": 55,
+        },
+    ), patch.object(
+        sched, "send_line"
+    ), patch.object(
+        sched, "send_telegram"
+    ), patch.object(
+        sched, "TradeSignalSender"
+    ) as sender_cls, patch(
+        "gpt_trader.utils.api_client.post_event"
+    ) as event_fn:
+        mock_sender = MagicMock()
+        mock_sender.lot = 0.1
+        mock_sender.rr = 1.5
+        mock_sender.risk_per_trade = 1.0
+        mock_sender.order_result = "success"
+        sender_cls.return_value = mock_sender
+        sched._run_workflow()
+
+    event_fn.assert_called_once()


### PR DESCRIPTION
## Summary
- add `post_event` HTTP helper
- export new helper
- call `post_event` from scheduler after notifications are sent
- test that events are posted when DB URL is configured

## Testing
- `pytest -q tests/test_main.py::test_notify_saved_to_db -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685edc6323708320a7ad49df421cac7b