### PR TITLE
Add signal_id to saved prompts

### DIFF
--- a/src/gpt_trader/send/send_to_gpt.py
+++ b/src/gpt_trader/send/send_to_gpt.py
@@ -76,13 +76,21 @@ def _timestamp_code(ts: datetime) -> str:
 
 
 def _save_prompt_copy(
-    json_path: Path, json_text: str, prompt: str, out_dir: Path
+    json_path: Path,
+    json_text: str,
+    prompt: str,
+    out_dir: Path,
+    signal_id: str | None = None,
 ) -> None:
-    """Save *json_text* and *prompt* to *out_dir* as one JSON file."""
+    """Save *json_text*, *prompt*, and *signal_id* to *out_dir* as one JSON file."""
     out_dir.mkdir(parents=True, exist_ok=True)
     ts = _timestamp_code(datetime.now(timezone.utc))
     base = f"{json_path.stem}_{ts}"
-    data = {"json": json.loads(json_text), "prompt": prompt}
+    data = {
+        "signal_id": signal_id or json_path.stem,
+        "json": json.loads(json_text),
+        "prompt": prompt,
+    }
     (out_dir / f"{base}.json").write_text(
         json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
     )
@@ -189,8 +197,9 @@ def main() -> None:
     if prompt is None:
         prompt = DEFAULT_PROMPT % json_path.stem
 
+    signal_id = json_path.stem
     try:
-        _save_prompt_copy(json_path, json_text, prompt, Path(args.save_dir))
+        _save_prompt_copy(json_path, json_text, prompt, Path(args.save_dir), signal_id)
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Failed to save prompt copy: %s", exc)
 

--- a/tests/test_send_to_gpt.py
+++ b/tests/test_send_to_gpt.py
@@ -20,9 +20,10 @@ def test_save_prompt_copy(tmp_path: Path) -> None:
     json_text = "{\"a\": 1}"
     json_path.write_text(json_text)
     out_dir = tmp_path / "out"
-    _save_prompt_copy(json_path, json_text, "Prompt", out_dir)
+    _save_prompt_copy(json_path, json_text, "Prompt", out_dir, "foo")
     files = list(out_dir.glob("*.json"))
     assert len(files) == 1
     data = json.loads(files[0].read_text())
     assert data["prompt"] == "Prompt"
     assert data["json"] == {"a": 1}
+    assert data["signal_id"] == "foo"


### PR DESCRIPTION
## Summary
- store the signal_id together with json/prompt when saving a GPT request
- update CLI call and tests

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f69a6e7308320b00d4d216cb16c17