### PR TITLE
Use minute-level timestamp for fetch output

### DIFF
--- a/src/gpt_trader/fetch/fetch_mt5_data.py
+++ b/src/gpt_trader/fetch/fetch_mt5_data.py
@@ -240,12 +240,8 @@ def main() -> None:
             LOGGER.error("No data available for the requested time_fetch")
             raise SystemExit(1)
         if output is None:
-            h1_label = _tf_label("H1")
-            h1_df = df[df["timeframe"] == h1_label]
-            last_ts = h1_df["timestamp"].max() if not h1_df.empty else df["timestamp"].max()
-            if pd.isna(last_ts):
-                raise RuntimeError("No timestamp found in fetched data")
-            name = _timestamp_code(last_ts)
+            ts_now = pd.Timestamp.utcnow().floor("min")
+            name = _timestamp_code(ts_now)
             output = Path(default_save_path) / f"{signal_prefix}{name}.csv"
         output.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(output, index=False)

--- a/src/gpt_trader/fetch/fetch_yf_data.py
+++ b/src/gpt_trader/fetch/fetch_yf_data.py
@@ -159,12 +159,8 @@ def main() -> None:
             LOGGER.error("No data available for the requested time_fetch")
             raise SystemExit(1)
         if output is None:
-            h1_label = _tf_label("H1")
-            h1_df = df[df["timeframe"] == h1_label]
-            last_ts = h1_df["timestamp"].max() if not h1_df.empty else df["timestamp"].max()
-            if pd.isna(last_ts):
-                raise RuntimeError("No timestamp found in fetched data")
-            name = _timestamp_code(last_ts)
+            ts_now = pd.Timestamp.utcnow().floor("min")
+            name = _timestamp_code(ts_now)
             output = Path(default_save_path) / f"{signal_prefix}{name}.csv"
         output.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(output, index=False)


### PR DESCRIPTION
## Summary
- name fetched files using current UTC time floored to minutes
- update both MT5 and yfinance fetch scripts

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_686126b9a84c8320a9a47e77b22c603b