### PR TITLE
Add account name to notifications

### DIFF
--- a/config/setting_live_trade.example.json
+++ b/config/setting_live_trade.example.json
@@ -48,6 +48,7 @@
     "neon": {"api_url": "http://localhost:3000", "database_url": ""},
     "risk_per_trade": 1.0,
     "max_risk_per_trade": 2.0,
+    "account_name": "DEMO_ACCOUNT",
     "notify": {
         "line": {"enabled": true, "token": "YOUR_LINE_TOKEN"},
         "telegram": {"enabled": false, "token": "", "chat_id": ""}

--- a/docs/usage_overall_th.md
+++ b/docs/usage_overall_th.md
@@ -23,8 +23,9 @@
    ความเสี่ยงต่อการเทรด
    - `risk_per_trade` ใช้เป็นเปอร์เซ็นต์คงที่ หากตั้งค่าไว้จะนำไปใช้แทน
      ค่าในไฟล์สัญญาณ
-   - `max_risk_per_trade` จะคำนวณจากค่าความมั่นใจของสัญญาณ โดยใช้สูตร
-     `(confidence / 100) * max_risk_per_trade` และไม่เกินค่านี้
+    - `max_risk_per_trade` จะคำนวณจากค่าความมั่นใจของสัญญาณ โดยใช้สูตร
+      `(confidence / 100) * max_risk_per_trade` และไม่เกินค่านี้
+    - `account_name` ระบุชื่อบัญชีที่จะใช้แสดงในข้อความแจ้งเตือน
 2. รันสคริปต์หลัก
    ```bash
    python src/gpt_trader/cli/live_trade_workflow.py

--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -131,11 +131,16 @@ def _next_window_run(
     return next_run
 
 
-def _format_summary_message(detail: str, status: str, signal: dict | None) -> str:
+def _format_summary_message(
+    detail: str, status: str, signal: dict | None, account: str | None = None
+) -> str:
     """Return a decorated summary string for notifications."""
     ts = datetime.now().isoformat(timespec="seconds")
     status_icon = "✅" if status == "success" else "⚠️"
-    parts = [f"📅 {ts}", f"{status_icon} {detail} ({status})"]
+    parts = [f"📅 {ts}"]
+    if account:
+        parts.append(f"🏦 account:{account}")
+    parts.append(f"{status_icon} {detail} ({status})")
     if signal:
         type_map = {
             "buy_limit": "🟢⬇️",
@@ -279,7 +284,8 @@ def _run_workflow() -> None:
         detail_items.append(f"order:{order_status}")
     detail = " ".join(detail_items)
 
-    message = _format_summary_message(detail, status, signal)
+    account_name = cfg.get("account_name")
+    message = _format_summary_message(detail, status, signal, account_name)
     LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     try:
         with LOG_FILE.open("a", encoding="utf-8") as f:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -155,7 +155,8 @@ def test_notify_called(tmp_path):
         "notify": {
             "line": {"enabled": True, "token": "t"},
             "telegram": {"enabled": True, "token": "tg", "chat_id": "id"},
-        }
+        },
+        "account_name": "acc",
     }
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text(json.dumps(cfg))
@@ -198,6 +199,7 @@ def test_notify_called(tmp_path):
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_called()
+    assert "account:acc" in line_fn.call_args[0][0]
     assert "signal_id:id" in line_fn.call_args[0][0]
     assert "regime_type:trend" in line_fn.call_args[0][0]
     assert "risk_per_trade:" in line_fn.call_args[0][0]
@@ -210,7 +212,8 @@ def test_notify_line_only(tmp_path):
         "notify": {
             "line": {"enabled": True, "token": "t"},
             "telegram": {"enabled": False, "token": "", "chat_id": ""},
-        }
+        },
+        "account_name": "acc",
     }
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text(json.dumps(cfg))
@@ -253,6 +256,7 @@ def test_notify_line_only(tmp_path):
         sched._run_workflow()
     line_fn.assert_called()
     tg_fn.assert_not_called()
+    assert "account:acc" in line_fn.call_args[0][0]
     assert "risk_per_trade:" in line_fn.call_args[0][0]
     assert "order:success" in line_fn.call_args[0][0]
 
@@ -262,7 +266,8 @@ def test_notify_telegram_only(tmp_path):
         "notify": {
             "line": {"enabled": False, "token": ""},
             "telegram": {"enabled": True, "token": "tg", "chat_id": "id"},
-        }
+        },
+        "account_name": "acc",
     }
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text(json.dumps(cfg))
@@ -305,6 +310,7 @@ def test_notify_telegram_only(tmp_path):
         sched._run_workflow()
     line_fn.assert_not_called()
     tg_fn.assert_called()
+    assert "account:acc" in tg_fn.call_args[0][0]
     assert "risk_per_trade:" in tg_fn.call_args[0][0]
     assert "order:success" in tg_fn.call_args[0][0]
 
@@ -314,7 +320,8 @@ def test_order_before_notification(tmp_path):
         "notify": {
             "line": {"enabled": True, "token": "t"},
             "telegram": {"enabled": False},
-        }
+        },
+        "account_name": "acc",
     }
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text(json.dumps(cfg))
@@ -366,6 +373,7 @@ def test_order_before_notification(tmp_path):
 
     assert calls == ["order", "notify"]
     msg = line_fn.call_args[0][0]
+    assert "account:acc" in msg
     assert "lot:" in msg
     assert "rr:" in msg
     assert "risk_per_trade:" in msg


### PR DESCRIPTION
## Summary
- include `account_name` in notification messages
- allow account name to be configured via `setting_live_trade.example.json`
- document new option in `usage_overall_th.md`
- update tests for account name field

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_686524ab1f788320b2ed4c7e33a68b0e