### PR TITLE
Improve regime type summary formatting

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -177,7 +177,14 @@ def _format_summary_message(
                 rr_fmt = str(signal['rr'])
             extra.append(f"📈 rr:{rr_fmt}")
         if signal.get("regime_type") is not None:
-            extra.append(f"📊 regime_type:{signal['regime_type']}")
+            regime = signal["regime_type"]
+            if isinstance(regime, dict):
+                regime_fmt = ", ".join(
+                    f"{k}={v}" for k, v in regime.items()
+                )
+            else:
+                regime_fmt = str(regime)
+            extra.append(f"📊 regime_type: {regime_fmt}")
         if extra:
             parts.append("")
             parts.append("\n".join(extra))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -296,7 +296,7 @@ def test_notify_called(tmp_path):
     tg_fn.assert_called()
     assert "account:acc" in line_fn.call_args[0][0]
     assert "signal_id:id" in line_fn.call_args[0][0]
-    assert "regime_type:trend" in line_fn.call_args[0][0]
+    assert "regime_type: trend" in line_fn.call_args[0][0]
     assert "risk_per_trade:" in line_fn.call_args[0][0]
     assert "short_reason:" in line_fn.call_args[0][0]
     assert "order:success" in line_fn.call_args[0][0]
@@ -472,7 +472,7 @@ def test_order_before_notification(tmp_path):
     assert "lot:" in msg
     assert "rr:" in msg
     assert "risk_per_trade:" in msg
-    assert "regime_type:trend" in msg
+    assert "regime_type: trend" in msg
     assert "short_reason:" in msg
     assert "order:success" in msg
 


### PR DESCRIPTION
## Summary
- format regime_type info in scheduler message for clarity
- update tests for new regime type formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_686628d516b0832094c2ad73ad36a5ea