### PR TITLE
Improve readability of short_reason in notifications

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, time as dt_time
 import logging
 import threading
 import time
+import re
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 
@@ -191,7 +192,9 @@ def _format_summary_message(
 
         if signal.get("short_reason") is not None:
             parts.append("")
-            parts.append(f"📝 short_reason:{signal['short_reason']}")
+            reason = str(signal["short_reason"])
+            reason_fmt = re.sub(r"(?<!^)(\d+\))", r"\n\1", reason).strip()
+            parts.append(f"📝 short_reason:{reason_fmt}")
         if signal.get("order_status") is not None:
             parts.append("")
             parts.append(f"🚩 order:{signal['order_status']}")


### PR DESCRIPTION
## Summary
- break long short_reason text into multiple lines for easier reading
- update scheduler_liveTrade to insert newlines before numbered points

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68665be9efb48320b8b94d2928a23549