### PR TITLE
Improve notification readability

### DIFF
--- a/src/gpt_trader/cli/scheduler_liveTrade.py
+++ b/src/gpt_trader/cli/scheduler_liveTrade.py
@@ -193,7 +193,7 @@ def _format_summary_message(
         if signal.get("short_reason") is not None:
             parts.append("")
             reason = str(signal["short_reason"])
-            reason_fmt = re.sub(r"(?<!^)(\d+\))", r"\n\1", reason).strip()
+            reason_fmt = re.sub(r"(?<!^)(\d+[\.)](?!\d))", r"\n\1", reason).strip()
             parts.append(f"📝 short_reason:{reason_fmt}")
         if signal.get("order_status") is not None:
             parts.append("")


### PR DESCRIPTION
## Summary
- handle enumerated lists that use `.` or `)` when formatting signal short reasons

## Testing
- `pytest -q` *(fails: pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_686666437e5883208b908ff52f17b63c