### PR TITLE
Add MT5 trade history fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cp src/gpt_trader/send/config/gpt.example.json src/gpt_trader/send/config/gpt.js
 
 สคริปต์ `fetch_mt5_data.py` อ่านค่าจาก `src/gpt_trader/fetch/config/fetch_mt5.json` สามารถกำหนดไฟล์อื่นด้วย `--config`
 ตัวอย่างคีย์ที่ใช้ได้ได้แก่ `symbol`, `fetch_bars`, `indicators`, `time_fetch`, `timeframes` และ `tz_shift`
+สำหรับบันทึกประวัติการเทรดใช้ `fetch_mt5_history.py` โดยกำหนดช่วงเวลาใน `src/gpt_trader/fetch/config/fetch_mt5_history.json`
 
 เมื่อรัน `live_trade_workflow.py` ให้สร้างไฟล์ `config/setting_live_trade.json` จากเทมเพลต
 

--- a/docs/files_overview_th.md
+++ b/docs/files_overview_th.md
@@ -33,6 +33,7 @@
 - `cli/liveTrade_scheduler.py` — ตัวอย่างตั้งเวลาเรียก `live_trade_workflow.py`
 - `fetch/fetch_mt5_data.py` — ดึงข้อมูลราคาและคำนวณ indicator ผ่าน MT5
 - `fetch/fetch_yf_data.py` — ดึงข้อมูลจาก yfinance
+- `fetch/fetch_mt5_history.py` — ดึงประวัติการเทรดจาก MT5 และบันทึกเป็น CSV
 - `send/send_to_gpt.py` — ส่งข้อมูลไป GPT และบันทึกสำเนา prompt
 - `parse/parse_gpt_response.py` — แปลงข้อความตอบกลับเป็นไฟล์สัญญาณ
 

--- a/src/gpt_trader/fetch/config/fetch_mt5_history.example.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5_history.example.json
@@ -1,0 +1,7 @@
+{
+  "tz_shift": 4,
+  "start": "2024-01-01 00:00:00",
+  "end": "2024-01-31 23:59:59",
+  "save_as_path": "data/live_trade/history",
+  "note": "Export trade history to CSV"
+}

--- a/src/gpt_trader/fetch/config/fetch_mt5_history.json
+++ b/src/gpt_trader/fetch/config/fetch_mt5_history.json
@@ -1,0 +1,6 @@
+{
+  "tz_shift": 4,
+  "start": "2024-01-01 00:00:00",
+  "end": "2024-01-31 23:59:59",
+  "save_as_path": "data/live_trade/history"
+}

--- a/src/gpt_trader/fetch/fetch_mt5_history.py
+++ b/src/gpt_trader/fetch/fetch_mt5_history.py
@@ -1,0 +1,104 @@
+"""Fetch trade history from MT5 and save to CSV."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+import MetaTrader5 as mt5
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _init_mt5() -> None:
+    """Initialize connection to MetaTrader5."""
+    if not mt5.initialize():
+        raise RuntimeError(f"MT5 initialize() failed: {mt5.last_error()}")
+
+
+def _shutdown_mt5() -> None:
+    """Shutdown MetaTrader5 connection."""
+    mt5.shutdown()
+
+
+def _load_config(path: Path) -> Dict[str, Any]:
+    """Load JSON configuration from *path*."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"Failed to read config: {exc}") from exc
+
+
+def _timestamp_code(ts: pd.Timestamp) -> str:
+    """Return the UNIX timestamp for *ts* as a string."""
+    return str(int(pd.Timestamp(ts).timestamp()))
+
+
+def fetch_history(config: Dict[str, Any], tz_shift: int = 0) -> pd.DataFrame:
+    """Return a DataFrame of trade history for the given config."""
+    start_str = str(config.get("start", ""))
+    end_str = str(config.get("end", ""))
+    if not start_str or not end_str:
+        raise ValueError("'start' and 'end' must be specified in config")
+    start = pd.to_datetime(start_str, errors="coerce")
+    end = pd.to_datetime(end_str, errors="coerce")
+    if pd.isna(start) or pd.isna(end):
+        raise ValueError("Invalid start or end timestamp")
+
+    deals = mt5.history_deals_get(start.to_pydatetime(), end.to_pydatetime())
+    if deals is None:
+        raise RuntimeError("Failed to fetch trade history")
+    if len(deals) == 0:
+        return pd.DataFrame()
+
+    records = [deal._asdict() for deal in deals]
+    df = pd.DataFrame.from_records(records)
+    if "time" in df.columns:
+        df["time"] = pd.to_datetime(df["time"], unit="s") + pd.Timedelta(hours=tz_shift)
+    return df
+
+
+def main() -> None:
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    default_cfg = Path(__file__).resolve().parent / "config" / "fetch_mt5_history.json"
+    pre_parser.add_argument("--config", help="Path to JSON config", default=str(default_cfg))
+
+    pre_args, remaining = pre_parser.parse_known_args()
+    config = _load_config(Path(pre_args.config))
+    default_tz = int(config.get("tz_shift", 0))
+    default_save_path = config.get("save_as_path", "data/live_trade/history")
+
+    parser = argparse.ArgumentParser(description="Fetch MT5 trade history", parents=[pre_parser])
+    parser.add_argument("--output", help="Output CSV file", default=None)
+    parser.add_argument("--tz-shift", type=int, default=default_tz, help="Hours to shift timestamps")
+    args = parser.parse_args(remaining)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    try:
+        _init_mt5()
+        df = fetch_history(config, tz_shift=args.tz_shift)
+        if df.empty:
+            LOGGER.error("No trade history available for the given period")
+            raise SystemExit(1)
+        output = Path(args.output) if args.output else None
+        if output is None:
+            ts_now = pd.Timestamp.utcnow().floor("min")
+            name = _timestamp_code(ts_now)
+            output = Path(default_save_path) / f"history{name}.csv"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(output, index=False)
+        LOGGER.info("Saved history to %s", output)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error("Error fetching history: %s", exc)
+        raise SystemExit(1)
+    finally:
+        _shutdown_mt5()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fetch_mt5_history.py
+++ b/tests/test_fetch_mt5_history.py
@@ -1,0 +1,93 @@
+import logging
+import json
+import sys
+import importlib
+from types import ModuleType, SimpleNamespace
+
+import pandas as pd
+import pytest
+
+
+def _make_mt5_stub(sample_time):
+    mt5 = ModuleType("MetaTrader5")
+    mt5.initialize = lambda: True
+    mt5.shutdown = lambda: None
+    deal = SimpleNamespace(ticket=1, time=int(sample_time.timestamp()))
+    mt5.history_deals_get = lambda start, end: [deal]
+    return mt5
+
+
+def test_fetch_history_tz_shift() -> None:
+    sample_time = pd.Timestamp("2024-01-01 00:00:00")
+    mt5 = _make_mt5_stub(sample_time)
+    with importlib.import_module("unittest.mock").patch.dict(sys.modules, {"MetaTrader5": mt5}):
+        mod = importlib.import_module("gpt_trader.fetch.fetch_mt5_history")
+        importlib.reload(mod)
+        cfg = {"start": "2024-01-01 00:00:00", "end": "2024-01-01 01:00:00"}
+        df = mod.fetch_history(cfg, tz_shift=2)
+    expected = sample_time + pd.Timedelta(hours=2)
+    assert df["time"].iloc[0] == expected
+
+
+def test_fetch_history_invalid_time() -> None:
+    mt5 = _make_mt5_stub(pd.Timestamp("2024-01-01"))
+    with importlib.import_module("unittest.mock").patch.dict(sys.modules, {"MetaTrader5": mt5}):
+        mod = importlib.import_module("gpt_trader.fetch.fetch_mt5_history")
+        importlib.reload(mod)
+        cfg = {"start": "bad", "end": "2024-01-01"}
+        with pytest.raises(ValueError):
+            mod.fetch_history(cfg)
+
+
+def test_main_writes_csv(tmp_path) -> None:
+    cfg = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-01 01:00:00",
+        "save_as_path": str(tmp_path),
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    df = pd.DataFrame({"time": [pd.Timestamp("2024-01-01")]})
+
+    with importlib.import_module("unittest.mock").patch.object(
+        sys,
+        "argv",
+        ["fetch_mt5_history.py", "--config", str(cfg_path)],
+    ), importlib.import_module("unittest.mock").patch(
+        "gpt_trader.fetch.fetch_mt5_history.fetch_history", return_value=df
+    ), importlib.import_module("unittest.mock").patch(
+        "gpt_trader.fetch.fetch_mt5_history._init_mt5"
+    ), importlib.import_module("unittest.mock").patch(
+        "gpt_trader.fetch.fetch_mt5_history._shutdown_mt5"
+    ):
+        importlib.import_module("gpt_trader.fetch.fetch_mt5_history").main()
+
+    csv_files = list(tmp_path.glob("*.csv"))
+    assert len(csv_files) == 1
+    assert pd.read_csv(csv_files[0]).iloc[0]["time"]
+
+
+def test_main_error_on_empty_df(tmp_path, caplog) -> None:
+    cfg = {
+        "start": "2024-01-01 00:00:00",
+        "end": "2024-01-01 01:00:00",
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    with importlib.import_module("unittest.mock").patch.object(
+        sys,
+        "argv",
+        ["fetch_mt5_history.py", "--config", str(cfg_path)],
+    ), importlib.import_module("unittest.mock").patch(
+        "gpt_trader.fetch.fetch_mt5_history.fetch_history", return_value=pd.DataFrame()
+    ), importlib.import_module("unittest.mock").patch(
+        "gpt_trader.fetch.fetch_mt5_history._init_mt5"
+    ), importlib.import_module("unittest.mock").patch(
+        "gpt_trader.fetch.fetch_mt5_history._shutdown_mt5"
+    ):
+        with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as exc:
+            importlib.import_module("gpt_trader.fetch.fetch_mt5_history").main()
+        assert exc.value.code == 1
+        assert "No trade history" in caplog.text


### PR DESCRIPTION
## Summary
- implement `fetch_mt5_history.py` to export trade history from MetaTrader5
- provide default configs for the new script
- document the new script in README and files overview
- add unit tests for history fetching logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: Required package 'pandas' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867a26acbe88320bd311cd8d018fe2f