### PR TITLE
Add config flag to scheduler

### DIFF
--- a/docs/usage_overall_th.md
+++ b/docs/usage_overall_th.md
@@ -35,9 +35,11 @@
 3. สำหรับการรันแบบอัตโนมัติ ให้เรียก `src/gpt_trader/cli/scheduler_liveTrade.py`
    เพื่อทำงานทุกชั่วโมง สคริปต์นี้สามารถรันได้โดยตรง เพราะ
    `live_trade_workflow.py` จะเพิ่ม path ของโปรเจกต์ให้อัตโนมัติ
-   ```bash
-   python src/gpt_trader/cli/scheduler_liveTrade.py
-   ```
+ ```bash
+  python src/gpt_trader/cli/scheduler_liveTrade.py
+  ```
+  สามารถระบุไฟล์คอนฟิกอื่นได้ด้วย `--config path/to/file.json`
+  หากไม่ระบุจะใช้ `config/setting_live_trade.json`
 
 ## 3. การรันโหมด Backtest
 


### PR DESCRIPTION
## Summary
- allow scheduler_liveTrade to accept `--config` parameter
- default to `config/setting_live_trade.json`
- pass config path through workflow runner
- document new flag in usage guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python -m py_compile src/gpt_trader/cli/scheduler_liveTrade.py`

------
https://chatgpt.com/codex/tasks/task_e_68724b025a408320b32b8c0619601dd7