### PR TITLE
Remove unused import in backtest CLI

### DIFF
--- a/src/gpt_trader/cli/main_backtest.py
+++ b/src/gpt_trader/cli/main_backtest.py
@@ -8,7 +8,6 @@ import asyncio
 import json
 import tempfile
 import logging
-import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- clean up unused `sys` import in main_backtest CLI
- run `ruff` to verify no F401 errors

## Testing
- `ruff check src/gpt_trader/cli/main_backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_68724cc32d208320bc32457965820f6f